### PR TITLE
Tasks to get monitoring token created

### DIFF
--- a/post-deployment/openstack/monitoring-sa.yml
+++ b/post-deployment/openstack/monitoring-sa.yml
@@ -1,0 +1,47 @@
+---
+- hosts: localhost
+  tasks:
+  - name: Create monitoring service account
+    k8s:
+      state: present
+      definition:
+        apiVersion: v1
+        kind: ServiceAccount
+        metadata:
+          name: monitoring
+          namespace: openshift-monitoring
+
+  - name: Add cluster-reader permissions to monitoring sa
+    command: oc adm policy add-cluster-role-to-user cluster-reader -z monitoring -n openshift-monitoring
+
+  - name: Register monitor var
+    k8s_info:
+      api_version: v1
+      kind: ServiceAccount
+      name: monitoring
+      namespace: openshift-monitoring
+    register: monitor_sa
+
+  - set_fact:
+      token_secret: "{{ monitor_sa.resources[0].secrets | to_json | from_json | json_query(jmesquery) }}"
+    vars:
+      jmesquery: "[?contains(name, 'token')].name | [0]"
+
+  - name: Get token
+    k8s_info:
+      api_version: v1
+      kind: secret
+      name: "{{ token_secret }}"
+      namespace: openshift-monitoring
+    register: token_json
+
+  - name: Verify token
+    uri:
+      url: https://api.{{ domainSuffix }}:6443/api/v1/nodes
+      return_content: yes
+      headers:
+        Authorization: "Bearer {{ token_json.resources[0].data.token | b64decode }}"
+
+  - name: Token to be added to monitoring_auth_token field in SINT
+    debug:
+      msg: "{{ token_json.resources[0].data.token | b64decode }}"

--- a/post-deployment/openstack/post-deployment.yml
+++ b/post-deployment/openstack/post-deployment.yml
@@ -7,3 +7,4 @@
 - import_playbook: dns-forwarding.yml
 - import_playbook: console-customization.yml
 - import_playbook: sso.yml
+- import_playbook: monitoring-sa.yml

--- a/post-deployment/openstack/vars.yml
+++ b/post-deployment/openstack/vars.yml
@@ -1,3 +1,4 @@
+domainSuffix: <domain suffix>
 # SSO parameters
 ssoSecret: <secret>
 ssoClientID: <client ID>


### PR DESCRIPTION
Post deployment task that creates monitoring service account, gives it cluster-reader permissions, verifies the token against the node api endpoint and prints it to be put in SINT. 

2nd task uses oc tools purely because editing the subjects section of the cluster-reader clusterrolebinding object will overwrite the array and although it is blank now could cause troubles if clusters come deployed with things assigned that role out the box in later versions or if it's re-run at any point. If we don't think this is a problem the task can be changed to k8s.