### PR TITLE
Remove Volume Zone Workarounds

### DIFF
--- a/post-deployment/openstack/infra.yml
+++ b/post-deployment/openstack/infra.yml
@@ -17,44 +17,6 @@
     vars:
       infrastructureIdQuery: "resources[0].status.infrastructureName"
 
-  - name: Create MachineConfig
-    k8s:
-      state: present
-      definition:
-        apiVersion: machineconfiguration.openshift.io/v1
-        kind: MachineConfig
-        metadata:
-          labels:
-            machineconfiguration.openshift.io/role: infra
-          name: 02-infra-kubelet
-        spec:
-          config:
-            ignition:
-              version: 2.2.0
-            systemd:
-              units:
-              - dropins:
-                - name: 20-infra-nodelabel.conf
-                  contents: |
-                    [Service]
-                    ExecStart=
-                    ExecStart=/usr/bin/hyperkube \
-                        kubelet \
-                          --config=/etc/kubernetes/kubelet.conf \
-                          --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
-                          --kubeconfig=/var/lib/kubelet/kubeconfig \
-                          --container-runtime=remote \
-                          --container-runtime-endpoint=/var/run/crio/crio.sock \
-                          --runtime-cgroups=/system.slice/crio.service \
-                          --node-labels=node-role.kubernetes.io/infra,node.openshift.io/os_id=${ID} \
-                          --minimum-container-ttl-duration=6m0s \
-                          --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
-                          --cloud-provider=openstack \
-                          --cloud-config=/etc/kubernetes/cloud.conf \
-                          --v=${KUBELET_LOG_LEVEL}
-                enabled: true
-                name: kubelet.service
-
   - name: Create MachineConfigPool
     k8s:
       state: present
@@ -187,45 +149,7 @@
               nodeSelector:
                 node-role.kubernetes.io/infra: ""
 
-  - name: Create scheduler policy configmap
-    k8s:
-      state: present
-      definition:  
-        apiVersion: v1
-        kind: ConfigMap
-        metadata:
-          name: scheduler-policy
-          namespace: openshift-config
-        data:
-          policy.cfg: |
-            {
-                "kind" : "Policy",
-                "apiVersion" : "v1",
-                "predicates" : [
-                        {"name" : "NoDiskConflict"},
-                        {"name" : "MaxEBSVolumeCount"},
-                        {"name" : "MaxAzureDiskVolumeCount"},
-                        {"name" : "MaxGCEPDVolumeCount"},
-                        {"name" : "MatchInterPodAffinity"},
-                        {"name" : "PodToleratesNodeTaints"},
-                        {"name" : "CheckNodeUnschedulable"},
-                        {"name" : "CheckVolumeBinding"},
-                        {"name" : "GeneralPredicates"},
-                        {"name" : "MaxCSIVolumeCountPred"}
-                        ],
-                "priorities" : [
-                        {"name" : "BalancedResourceAllocation", "weight" : 1},
-                        {"name" : "ImageLocalityPriority", "weight" : 1},
-                        {"name" : "InterPodAffinityPriority", "weight" : 1},
-                        {"name" : "LeastRequestedPriority", "weight" : 1},
-                        {"name" : "NodeAffinityPriority", "weight" : 1},
-                        {"name" : "NodePreferAvoidPodsPriority", "weight" : 1},
-                        {"name" : "SelectorSpreadPriority", "weight" : 1},
-                        {"name" : "TaintTolerationPriority", "weight" : 1}
-                        ]
-              }
-
-  - name: Create default nodeSelector to target workers and amend scheduler policy to mitigate volume zone issue
+  - name: Create default nodeSelector to target workers
     k8s:
       state: present
       definition:
@@ -236,5 +160,3 @@
         spec:
           defaultNodeSelector: node-role.kubernetes.io/worker=
           mastersSchedulable: false
-          policy:
-            name: "scheduler-policy"

--- a/post-deployment/openstack/logging.yml
+++ b/post-deployment/openstack/logging.yml
@@ -137,12 +137,29 @@
           source: redhat-operators
           sourceNamespace: openshift-marketplace
 
+  - name: Wait 2 minutes for MachineConfigPool status to stabilise because cloud-provider-config has been changed
+    pause:
+      seconds: 120
+    when: cloudproviderConfigchanged is defined and cloudproviderConfigchanged
+
+  - name: Wait for MachineConfigPools to all become Updated
+    k8s_info:
+      kind: MachineConfigPool
+    register: machineConfigPoolStatus
+    until:
+      - machineConfigPoolStatus.resources | length > 0
+      - machineConfigPoolStatus.resources[0].status.readyMachineCount == machineConfigPoolStatus.resources[0].status.machineCount
+      - machineConfigPoolStatus.resources[1].status.readyMachineCount is not defined or machineConfigPoolStatus.resources[1].status.readyMachineCount == machineConfigPoolStatus.resources[1].status.machineCount
+      - machineConfigPoolStatus.resources[2].status.readyMachineCount is not defined or machineConfigPoolStatus.resources[2].status.readyMachineCount == machineConfigPoolStatus.resources[2].status.machineCount
+    retries: 200
+    delay: 3
+
   - name: Wait for operator pod to be Ready
     k8s_info:
       kind: Pod
       namespace: openshift-logging
       label_selectors:
-        - name = cluster-logging-operator 
+        - name = cluster-logging-operator
     register: operatorPodStatus
     until:
       - operatorPodStatus.resources | length > 0

--- a/post-deployment/openstack/storage.yml
+++ b/post-deployment/openstack/storage.yml
@@ -1,6 +1,39 @@
 ---
 - hosts: localhost
   tasks:
+  - name: Get cloud-provider-config ConfigMap
+    k8s_info:
+      kind: ConfigMap
+      name: cloud-provider-config
+      namespace: openshift-config
+    register: cloudproviderconfigConfigMap
+
+  - name: Get cloud-provider-config data
+    set_fact:
+      cloudproviderConfig: '{{ cloudproviderconfigConfigMap.resources[0].data.config }}'
+
+  - name: Note in a fact whether cloud-provider-config will be changed
+    set_fact:
+      cloudproviderConfigchanged: true
+    when: not cloudproviderConfig is search("ignore-volume-az")
+
+  - name: Alter cloud-provider-config to include ignore-volume-az if it isnt there already
+    k8s:
+      state: present
+      definition:
+        kind: ConfigMap
+        apiVersion: v1
+        metadata:
+          name: cloud-provider-config
+          namespace: openshift-config
+        data:
+          config: |
+            {{ cloudproviderConfig }}
+            [BlockStorage]
+            ignore-volume-az = yes
+    when: not cloudproviderConfig is search("ignore-volume-az")
+
+
   - name: Unset default storage class from standard SC
     k8s:
       state: present
@@ -47,30 +80,6 @@
         provisioner: kubernetes.io/cinder
         reclaimPolicy: Delete
         volumeBindingMode: Immediate
-
-  - name: Get nodes
-    k8s_info:
-      kind: Node
-    register: k8s_nodes
-
-  - name: Build node name dict
-    set_fact:
-      nodes: '{{ nodes | default([]) + [ k8s_nodes | to_json | from_json | json_query(nodesQuery) ] }}'
-    vars:
-      nodesQuery: "resources[*].metadata.name"
-
-  - name: Add empty region label and change zone to nova
-    k8s:
-      state: present
-      definition:
-        apiVersion: v1
-        kind: Node
-        metadata:
-          name: "{{ item }}"
-          labels:
-            failure-domain.beta.kubernetes.io/region: ""
-            failure-domain.beta.kubernetes.io/zone: "nova"
-    with_items: "{{ nodes }}"
 
   - name: Remove image registry PVC created during IPI deployment
     k8s:


### PR DESCRIPTION
Implements ignore-volume-az cloud-provider-config fix, and removes elements that are made unnecessary by it (eg node labelling). 

A rather odd delay is necessary in the logging.yml playbook because it takes a variable amount of time for the MCP statuses to change to Updating. Therefore, it has a 2 minute delay in logging.yml which only occurs if storage.yml sets a fact which denotes that the cloud-provider-config was changed.

Also, an unrelated change: this removes the custom kubelet command-line used for infra nodes: it was found to be unnecessary for v4.4 and later.