### PR TITLE
Gedev10 -> master for next deploy

### DIFF
--- a/upi/vsphere/stage1/3a.create-rhel-bastion/main.tf
+++ b/upi/vsphere/stage1/3a.create-rhel-bastion/main.tf
@@ -30,7 +30,7 @@ module "bastion" {
   names            = [var.bastion.hostname]
   instance_count   = 1
   num_cpu          = 1
-  memory           = 2048
+  memory           = 4096
   disk_size        = 100
   resource_pool_id = data.vsphere_resource_pool.management_pool.id
   datastore        = var.management.vsphere_datastore

--- a/upi/vsphere/stage1/3b.configure-rhel-bastion/playbooks/templates/rhel_satellite.sh.j2
+++ b/upi/vsphere/stage1/3b.configure-rhel-bastion/playbooks/templates/rhel_satellite.sh.j2
@@ -34,7 +34,7 @@ yum install -y katello-agent
 openshiftPoolId=$(subscription-manager list --available --matches='Red Hat OpenShift Container Platform for Certified Cloud and Service Providers' | awk '/System Type:\s*Physical/' RS='\n\n' | awk '/Pool ID/ {print $NF}')
 
 # setup repos & install software packages
-retry subscription-manager attach --pool=$openshiftPoolId
+subscription-manager attach --pool=$openshiftPoolId
 retry subscription-manager repos --disable=*
 
 retry subscription-manager repos \

--- a/upi/vsphere/stage1/3b.configure-rhel-bastion/playbooks/templates/rhel_satellite.sh.j2
+++ b/upi/vsphere/stage1/3b.configure-rhel-bastion/playbooks/templates/rhel_satellite.sh.j2
@@ -31,10 +31,10 @@ subscription-manager repos --enable=rhel-7-server-satellite-tools-6.5-rpms
 yum install -y katello-agent
 
 # determine pool ID's for red hat subscriptions
-#openshiftPoolId=$(subscription-manager list --available --matches='Red Hat OpenShift Container Platform for Certified Cloud and Service Providers' | awk '/System Type:\s*Physical/' RS='\n\n' | awk '/Pool ID/ {print $NF}')
+openshiftPoolId=$(subscription-manager list --available --matches='Red Hat OpenShift Container Platform for Certified Cloud and Service Providers' | awk '/System Type:\s*Physical/' RS='\n\n' | awk '/Pool ID/ {print $NF}')
 
 # setup repos & install software packages
-#retry subscription-manager attach --pool=$openshiftPoolId
+retry subscription-manager attach --pool=$openshiftPoolId
 retry subscription-manager repos --disable=*
 
 retry subscription-manager repos \

--- a/upi/vsphere/stage1/build.sh
+++ b/upi/vsphere/stage1/build.sh
@@ -6,10 +6,10 @@ read TAG
 echo "Enter the registry url prefix (without trailing /):"
 read PREFIX
 
-podman build ./1.setup-env -t ${PREFIX}/1.setup-env:${TAG} --no-cache
+podman build --format=docker ./1.setup-env -t ${PREFIX}/1.setup-env:${TAG} --no-cache
 podman build --format=docker ./2.create-config -t ${PREFIX}/2.create-config:${TAG} --no-cache
-podman build ./3a.create-rhel-bastion -t ${PREFIX}/3a.create-rhel-bastion:${TAG} --no-cache
-podman build ./3b.configure-rhel-bastion -t ${PREFIX}/3b.configure-rhel-bastion:${TAG} --no-cache
+podman build --format=docker ./3a.create-rhel-bastion -t ${PREFIX}/3a.create-rhel-bastion:${TAG} --no-cache
+podman build --format=docker ./3b.configure-rhel-bastion -t ${PREFIX}/3b.configure-rhel-bastion:${TAG} --no-cache
 
 podman tag docker.io/coredns/coredns:latest ${PREFIX}/coredns:${TAG}
 

--- a/upi/vsphere/stage2/7.terraform-deploy/rhcos_machine/main.tf
+++ b/upi/vsphere/stage2/7.terraform-deploy/rhcos_machine/main.tf
@@ -30,7 +30,7 @@ resource "vsphere_virtual_machine" "vm" {
   wait_for_guest_net_routable = "false"
 
   lifecycle {
-    ignore_changes = [datastore_id, cpu_reservation, cpu_share_count, cpu_share_level, num_cores_per_socket, num_cpus, memory_hot_add_enabled, memory_limit, memory_reservation, memory_share_count, memory_share_level, ]
+    ignore_changes = [disk, datastore_id, cpu_reservation, cpu_share_count, cpu_share_level, num_cores_per_socket, num_cpus, memory_hot_add_enabled, memory_limit, memory_reservation, memory_share_count, memory_share_level, ]
   }
 
   network_interface {

--- a/upi/vsphere/stage2/7.terraform-deploy/rhcos_machine/main.tf
+++ b/upi/vsphere/stage2/7.terraform-deploy/rhcos_machine/main.tf
@@ -29,6 +29,10 @@ resource "vsphere_virtual_machine" "vm" {
   wait_for_guest_net_timeout  = "0"
   wait_for_guest_net_routable = "false"
 
+  lifecycle {
+    ignore_changes = [datastore_id, cpu_reservation, cpu_share_count, cpu_share_level, num_cores_per_socket, num_cpus, memory_hot_add_enabled, memory_limit, memory_reservation, memory_share_count, memory_share_level, ]
+  }
+
   network_interface {
     network_id = data.vsphere_network.network.id
   }

--- a/upi/vsphere/stage2/7.terraform-deploy/rhel_machine/main.tf
+++ b/upi/vsphere/stage2/7.terraform-deploy/rhel_machine/main.tf
@@ -30,7 +30,7 @@ resource "vsphere_virtual_machine" "vm" {
   wait_for_guest_net_routable = "false"
 
   lifecycle {
-    ignore_changes = [datastore_id, cpu_reservation, cpu_share_count, cpu_share_level, num_cores_per_socket, num_cpus, memory_hot_add_enabled, memory_limit, memory_reservation, memory_share_count, memory_share_level, ]
+    ignore_changes = [disk, datastore_id, cpu_reservation, cpu_share_count, cpu_share_level, num_cores_per_socket, num_cpus, memory_hot_add_enabled, memory_limit, memory_reservation, memory_share_count, memory_share_level, ]
   }
 
   network_interface {

--- a/upi/vsphere/stage2/7.terraform-deploy/rhel_machine/main.tf
+++ b/upi/vsphere/stage2/7.terraform-deploy/rhel_machine/main.tf
@@ -29,6 +29,10 @@ resource "vsphere_virtual_machine" "vm" {
   wait_for_guest_net_timeout  = "0"
   wait_for_guest_net_routable = "false"
 
+  lifecycle {
+    ignore_changes = [datastore_id, cpu_reservation, cpu_share_count, cpu_share_level, num_cores_per_socket, num_cpus, memory_hot_add_enabled, memory_limit, memory_reservation, memory_share_count, memory_share_level, ]
+  }
+
   network_interface {
     network_id = data.vsphere_network.network.id
   }

--- a/upi/vsphere/stage2/7.terraform-deploy/variables.tf
+++ b/upi/vsphere/stage2/7.terraform-deploy/variables.tf
@@ -74,7 +74,7 @@ variable "svc_num_cpu" {
 variable "svc_memory" {
   type = string
   description = "RAM size in megabytes"
-  default = "1024"
+  default = "4096"
 }
 
 variable "svc_disk_size" {

--- a/upi/vsphere/stage2/8.configure-svcs/playbooks/templates/rhel_satellite.sh.j2
+++ b/upi/vsphere/stage2/8.configure-svcs/playbooks/templates/rhel_satellite.sh.j2
@@ -34,7 +34,7 @@ yum install -y katello-agent
 openshiftPoolId=$(subscription-manager list --available --matches='Red Hat OpenShift Container Platform for Certified Cloud and Service Providers' | awk '/System Type:\s*Physical/' RS='\n\n' | awk '/Pool ID/ {print $NF}')
 
 # setup repos & install software packages
-retry subscription-manager attach --pool=$openshiftPoolId
+subscription-manager attach --pool=$openshiftPoolId
 retry subscription-manager repos --disable=*
 
 retry subscription-manager repos \

--- a/upi/vsphere/stage2/8.configure-svcs/playbooks/templates/rhel_satellite.sh.j2
+++ b/upi/vsphere/stage2/8.configure-svcs/playbooks/templates/rhel_satellite.sh.j2
@@ -31,10 +31,10 @@ subscription-manager repos --enable=rhel-7-server-satellite-tools-6.5-rpms
 yum install -y katello-agent
 
 # determine pool ID's for red hat subscriptions
-#openshiftPoolId=$(subscription-manager list --available --matches='Red Hat OpenShift Container Platform for Certified Cloud and Service Providers' | awk '/System Type:\s*Physical/' RS='\n\n' | awk '/Pool ID/ {print $NF}')
+openshiftPoolId=$(subscription-manager list --available --matches='Red Hat OpenShift Container Platform for Certified Cloud and Service Providers' | awk '/System Type:\s*Physical/' RS='\n\n' | awk '/Pool ID/ {print $NF}')
 
 # setup repos & install software packages
-#retry subscription-manager attach --pool=$openshiftPoolId
+retry subscription-manager attach --pool=$openshiftPoolId
 retry subscription-manager repos --disable=*
 
 retry subscription-manager repos \

--- a/upi/vsphere/stage2/9.post-deployment/playbooks/post_deployment.yaml
+++ b/upi/vsphere/stage2/9.post-deployment/playbooks/post_deployment.yaml
@@ -2,5 +2,5 @@
 - import_playbook: default_project.yaml
 - import_playbook: disable_self_provisioning.yaml
 - import_playbook: infra.yaml
-- import_playbook: object_storage.yaml
+  #- import_playbook: object_storage.yaml
 - import_playbook: ingress_controller.yaml


### PR DESCRIPTION
Minor changes to vSphere UPI code only:
- disable adding S3/ECS registry storage by default (because of connectivity issues meaning PVC registry storage is to be used)
- make the satellite scripts attempt to add RHEL servers to pool, mainly to allow code to work with dev satellite
- change format of stage1 contains so they can be pushed to nexus
- increase RAM for RHEL servers to perverse levels so that they can support Cisco AMP


- added clause to machine terraform so that various parameters are ignored so that deliberate operational changes aren't reverted during scaling