### PR TITLE
Fix really stupid use of rm -f in coredns service file

### DIFF
--- a/upi/vsphere/stage2/8.configure-svcs/playbooks/templates/coredns.service.j2
+++ b/upi/vsphere/stage2/8.configure-svcs/playbooks/templates/coredns.service.j2
@@ -4,8 +4,8 @@ Wants=crio.service
 [Service]
 Restart=always
 RestartSec=1
-ExecStartPre=-/usr/bin/podman rm -f coredns
-ExecStart=/usr/bin/podman run -a=STDOUT --name coredns -v /etc/coredns:/etc/coredns:z --network host -p 53:53/udp {{ registry_url }}/coredns:{{ image_tag }} --conf /etc/coredns/Corefile
-ExecStop=/usr/bin/podman rm -f coredns
+ExecStartPre=-/usr/bin/podman stop coredns
+ExecStart=/usr/bin/podman run --rm=true -a=STDOUT --name coredns -v /etc/coredns:/etc/coredns:z --network host -p 53:53/udp {{ registry_url }}/coredns:{{ image_tag }} --conf /etc/coredns/Corefile
+ExecStop=/usr/bin/podman stop coredns
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Something I've been meaning to fix for a while - remove the idiotic use of `podman rm -f` in the coredns service file. Using rm -f causes the container's storage to hang around meaning that it cannot start until the storage is removed using `podman rm --storage coredns` - this patch fixes this.

Tag moved to 1.12c because this is a fix that was put in place in an running environment to fix an issue.