### PR TITLE
vars.yml alignment with openshift-upi-ansible

### DIFF
--- a/post-deployment/openstack/README.md
+++ b/post-deployment/openstack/README.md
@@ -13,7 +13,7 @@ deploy.sh
 Alternatively you can run through each playbook included in post-deployment.yml separately ensuring to use vars.yml with each then run opsview-metadata.py.
 
 
-##vars.yml format
+## vars.yml format
 
 Note that the `vars.yml` format has been changed to match the `vars.yml` used by openshift-upi-ansible deployment code. This means the same `vars.yml` can be used for deployment and post-deployment.
 

--- a/post-deployment/openstack/README.md
+++ b/post-deployment/openstack/README.md
@@ -4,10 +4,30 @@ Ensure you have set the `KUBECONFIG` variable in your shell referencing a valid 
 export KUBECONFIG=/path/to/kubeconfig
 ```
 
-Populate vars.yml then run post-deployment code:
+Populate `vars.yml` then run post-deployment code (the example file contains definitions of the parameters):
 
 ```
 deploy.sh
 ```
 
 Alternatively you can run through each playbook included in post-deployment.yml separately ensuring to use vars.yml with each then run opsview-metadata.py.
+
+
+##vars.yml format
+
+Note that the `vars.yml` format has been changed to match the `vars.yml` used by openshift-upi-ansible deployment code. This means the same `vars.yml` can be used for deployment and post-deployment.
+
+Retains compatibility with the old format used previously.
+
+Meaning that (new format):
+```
+custID: <Estate API ID for cluster (string)>      
+baseDomain: <Base domain for OSP region (string)>   
+rhcosImage: <rhcos image present in OSP project (NAME)> 
+```
+is equivalent to (old format):
+```
+imageName: <image present in project> 
+domainSuffix: <domain suffix> 
+```
+(where `domainSuffix` is `custID.baseDomain` - so either `domainSuffix` OR (`custID` AND `baseDomain`) must be in `vars.yml`

--- a/post-deployment/openstack/opsview-metadata.py
+++ b/post-deployment/openstack/opsview-metadata.py
@@ -16,7 +16,11 @@ def Vars():
     with open('vars.yml') as f:
         data = yaml.load(f)
 
-    domain = data['domainSuffix']
+    if 'domainSuffix' in data:
+        domain = data['domainSuffix']
+    else:
+        domain = data['custID'] + '.' + data['baseDomain']
+
     api = 'api.{}'.format(domain)
     name = data['opsviewName']
     logging = data['logging']

--- a/post-deployment/openstack/post-deployment.yml
+++ b/post-deployment/openstack/post-deployment.yml
@@ -1,13 +1,16 @@
 ---
-- name: Check for legacy imageName var
-  set_fact: 
-    rhcosImage: "{{ imageName }}"
-  when: rhcosImage is not defined
+- hosts: localhost
+  gather_facts: False
+  tasks:
+  - name: Check for legacy imageName var
+    set_fact: 
+      rhcosImage: "{{ imageName }}"
+    when: rhcosImage is not defined
 
-- name: Set domainSuffix
-  set_fact:
-    domainSuffix: "{{ custID }}.{{ baseDomain }}"
-  when: domainSuffix is not defined
+  - name: Set domainSuffix
+    set_fact:
+      domainSuffix: "{{ custID }}.{{ baseDomain }}"
+    when: domainSuffix is not defined
 
 - import_playbook: object-storage.yml
 - import_playbook: infra.yml

--- a/post-deployment/openstack/post-deployment.yml
+++ b/post-deployment/openstack/post-deployment.yml
@@ -1,4 +1,14 @@
 ---
+- name: Check for legacy imageName var
+  set_fact: 
+    rhcosImage: "{{ imageName }}"
+  when: rhcosImage is not defined
+
+- name: Set domainSuffix
+  set_fact:
+    domainSuffix: "{{ custID }}.{{ baseDomain }}"
+  when: domainSuffix is not defined
+
 - import_playbook: object-storage.yml
 - import_playbook: infra.yml
 - import_playbook: storage.yml

--- a/post-deployment/openstack/templates/machineset.j2
+++ b/post-deployment/openstack/templates/machineset.j2
@@ -30,8 +30,8 @@ spec:
             name: openstack-cloud-credentials
             namespace: openshift-machine-api
           flavor: ocp.m1.medium
-{% if imageName is defined %}
-          image: "{{ imageName }}"
+{% if rhcosImage is defined %}
+          image: "{{ rhcosImage }}"
 {% else %}
           image: "{{ infrastructureId }}-rhcos"
 {% endif %}

--- a/post-deployment/openstack/vars.yml
+++ b/post-deployment/openstack/vars.yml
@@ -1,4 +1,4 @@
-imageName: <Name of image if using one in glance. If you want the installer to upload comment this variable out>
+rhcosImage: #  imageName: <Name of image if using one in glance. If you want the installer to upload comment this variable out>
 domainSuffix: <domain suffix>
 # SSO parameters
 ssoSecret: <secret>

--- a/post-deployment/openstack/vars.yml
+++ b/post-deployment/openstack/vars.yml
@@ -1,5 +1,5 @@
-rhcosImage: #  imageName: <Name of image if using one in glance. If you want the installer to upload comment this variable out>
-domainSuffix: <domain suffix>
+rhcosImage: <image present in project> # <Name of image to use for deploying infra nodes>
+domainSuffix: <domain suffix> # Can also be specified in two params "custID" and "baseDomain"
 # SSO parameters
 ssoSecret: <secret>
 ssoClientID: <client ID>


### PR DESCRIPTION
Alters the code to be able to use the same `vars.yml` params as openshift-upi-ansible (where they overlap in purpose), meaning that a single `vars.yml` can be used with both steps.

Retains compatibility with the old format.

Means that:
```
custID: <Estate API ID for cluster (string)>			
baseDomain: <Base domain for OSP region (string)>		
rhcosImage: <rhcos image present in OSP project (NAME)>	
```
is equivalent to:
```
imageName: <image present in project> 
domainSuffix: <domain suffix> 
```
(where `domainSuffix` is `custID.baseDomain` - so either `domainSuffix` OR (`custID` AND `baseDomain`) must be in `vars.yml`
