### PR TITLE
Improve 8.configure-svcs (VMware UPI deploy/scaling)

### DIFF
--- a/upi/vsphere/stage2/8.configure-svcs/Dockerfile
+++ b/upi/vsphere/stage2/8.configure-svcs/Dockerfile
@@ -1,5 +1,4 @@
-FROM docker.io/ansible/ansible-runner@sha256:607c86d1d7436cf937b285603b5335076140cd0ecb550741ca2c30e7bb00cca3
+FROM docker.io/ansible/ansible-runner@sha256:bd09ef403f2f90f2c6bd133d7533e939058903f69223c5f12557a49e3aed14bb
 ADD ./playbooks /usr/local/playbooks
-RUN yum -y install sshpass; yum clean all
 WORKDIR /tmp/workingdir
 ENTRYPOINT /usr/local/playbooks/entrypoint.sh

--- a/upi/vsphere/stage2/8.configure-svcs/playbooks/configure_svc_dns.yaml
+++ b/upi/vsphere/stage2/8.configure-svcs/playbooks/configure_svc_dns.yaml
@@ -1,168 +1,64 @@
 ---
+- hosts: svcs, asvcs, csvcs, esvcs
+  tasks:
+  - name: Make the /etc/coredns directory
+    file:
+      path: /etc/coredns
+      state: directory
 
-- hosts: localhost
+  - name: Make the Zonefile
+    template:
+      src: templates/zonefile.j2
+      dest: /etc/coredns/{{ domain_suffix }}.zone
+   
+  - name: Make a Unit file for coredns.service
+    template:
+      src: templates/coredns.service.j2
+      dest: /etc/systemd/system/coredns.service
+
+- hosts: svcs
   vars:
     dns_server1: "{{ man_dns_server1 }}"
     dns_server2: "{{ man_dns_server2 }}"
   tasks:
-  - name: Create /tmp/workingdir/dns/ directory
-    file:
-      path: /tmp/workingdir/dns/
-      state: directory
-
-  - name: Make a Zonefile
-    template:
-      src: templates/zonefile.j2
-      dest: /tmp/workingdir/dns/{{ domain_suffix }}.zone
-
-  - name: Make a mgmt Corefile config
+  - name: Make a Corefile on the svcs VMs (only if it doesn't exist)
     template:
       src: templates/Corefile.j2
-      dest: /tmp/workingdir/dns/manCorefile
-
-  - name: Make a Unit file for coredns.service
-    template:
-      src: templates/coredns.service.j2
-      dest: /tmp/workingdir/dns/coredns.service
-
-
-
-- hosts: localhost
+      dest: /etc/coredns/Corefile
+      force: no
+      
+- hosts: asvcs
   vars:
     dns_server1: "{{ assured_dns_server1 }}"
     dns_server2: "{{ assured_dns_server2 }}"
   tasks:
-  - name: Make an assured Corefile config
+  - name: Make a Corefile on the asvcs VMs (only if it doesn't exist)
     template:
       src: templates/Corefile.j2
-      dest: /tmp/workingdir/dns/assCorefile
-      
-
-- hosts: localhost
-  vars:
+      dest: /etc/coredns/Corefile
+      force: no      
+  
+- hosts: csvcs
+  vars: 
     dns_server1: "{{ combined_dns_server1 }}"
     dns_server2: "{{ combined_dns_server2 }}"
   tasks:
-  - name: Make a combined Corefile config
+  - name: Make a Corefile on the csvcs VMs (only if it doesn't exist)
     template:
       src: templates/Corefile.j2
-      dest: /tmp/workingdir/dns/comCorefile
-      
-- hosts: localhost
+      dest: /etc/coredns/Corefile
+      force: no  
+
+- hosts: esvcs
   vars:
     dns_server1: "{{ elevated_dns_server1 }}"
     dns_server2: "{{ elevated_dns_server2 }}"
   tasks:
-  - name: Make an elevated Corefile config
+  - name: Make a Corefile on the esvcs VMs (only if it doesn't exist)
     template:
       src: templates/Corefile.j2
-      dest: /tmp/workingdir/dns/eleCorefile
-      
-- hosts: svcs
-  gather_facts: false
-  tasks:
-  - name: Create /etc/coredns directory
-    raw: mkdir -p /etc/coredns
-
-  - name: Push Zonefile
-    raw: echo '{{ lookup('file', '/tmp/workingdir/dns/{{ domain_suffix }}.zone') }}' > /etc/coredns/{{ domain_suffix }}.zone
-
-  - name: Push Corefile - only if it doesnt exist
-    raw: set -o noclobber; echo "{{ lookup('file', '/tmp/workingdir/dns/manCorefile') }}" > /etc/coredns/Corefile
-    ignore_errors: True
-
-  - name: Push Unit file
-    raw: echo "{{ lookup('file', '/tmp/workingdir/dns/coredns.service') }}" > /etc/systemd/system/coredns.service
-
-  - name: Login to registry to pull image
-    raw: podman login --tls-verify=false  -u "{{ registry_username }}" -p "{{ registry_token }}" https://{{ registry_url }}
-    when: registry_username != ""
-
-  - name: Pull CoreDNS container
-    raw: podman pull --tls-verify=false {{ registry_url }}/coredns:{{ image_tag }}
-
-  - name: Enable coredns.service
-    raw: sudo systemctl stop coredns.service; sudo systemctl daemon-reload; sudo systemctl enable coredns.service; sudo systemctl start coredns.service
-    
-- hosts: asvcs
-  gather_facts: false
-  tasks:
-  - name: Create /etc/coredns directory
-    raw: mkdir -p /etc/coredns
-
-  - name: Push Zonefile
-    raw: echo '{{ lookup('file', '/tmp/workingdir/dns/{{ domain_suffix }}.zone') }}' > /etc/coredns/{{ domain_suffix }}.zone
-
-  - name: Push Corefile - only if it doesnt exist
-    raw: set -o noclobber; echo "{{ lookup('file', '/tmp/workingdir/dns/assCorefile') }}" > /etc/coredns/Corefile
-    ignore_errors: True
-
-  - name: Push Unit file
-    raw: echo "{{ lookup('file', '/tmp/workingdir/dns/coredns.service') }}" > /etc/systemd/system/coredns.service
-
-  - name: Login to registry to pull image
-    raw: podman login --tls-verify=false  -u "{{ registry_username }}" -p "{{ registry_token }}" https://{{ registry_url }}
-    when: registry_username != ""
-
-  - name: Pull CoreDNS container
-    raw: podman pull --tls-verify=false {{ registry_url }}/coredns:{{ image_tag }}
-
-  - name: Enable coredns.service
-    raw: sudo systemctl stop coredns.service; sudo systemctl daemon-reload; sudo systemctl enable coredns.service; sudo systemctl start coredns.service
-
-
-- hosts: csvcs
-  gather_facts: false
-  tasks:
-  - name: Create /etc/coredns directory
-    raw: mkdir -p /etc/coredns
-
-  - name: Push Zonefile
-    raw: echo '{{ lookup('file', '/tmp/workingdir/dns/{{ domain_suffix }}.zone') }}' > /etc/coredns/{{ domain_suffix }}.zone
-
-  - name: Push Corefile - only if it doesnt exist
-    raw: set -o noclobber; echo "{{ lookup('file', '/tmp/workingdir/dns/comCorefile') }}" > /etc/coredns/Corefile
-    ignore_errors: True
-
-  - name: Push Unit file
-    raw: echo "{{ lookup('file', '/tmp/workingdir/dns/coredns.service') }}" > /etc/systemd/system/coredns.service
-
-  - name: Login to registry to pull image
-    raw: podman login --tls-verify=false  -u "{{ registry_username }}" -p "{{ registry_token }}" https://{{ registry_url }}
-    when: registry_username != ""
-
-  - name: Pull CoreDNS container
-    raw: podman pull --tls-verify=false {{ registry_url }}/coredns:{{ image_tag }}
-
-  - name: Enable coredns.service
-    raw: sudo systemctl stop coredns.service; sudo systemctl daemon-reload; sudo systemctl enable coredns.service; sudo systemctl start coredns.service
-
-
-- hosts: esvcs
-  gather_facts: false
-  tasks:
-  - name: Create /etc/coredns directory
-    raw: mkdir -p /etc/coredns
-
-  - name: Push Zonefile
-    raw: echo '{{ lookup('file', '/tmp/workingdir/dns/{{ domain_suffix }}.zone') }}' > /etc/coredns/{{ domain_suffix }}.zone
-
-  - name: Push Corefile - only if it doesnt exist
-    raw: set -o noclobber; echo "{{ lookup('file', '/tmp/workingdir/dns/eleCorefile') }}" > /etc/coredns/Corefile
-    ignore_errors: True
-
-  - name: Push Unit file
-    raw: echo "{{ lookup('file', '/tmp/workingdir/dns/coredns.service') }}" > /etc/systemd/system/coredns.service
-
-  - name: Login to registry to pull image
-    raw: podman login --tls-verify=false  -u "{{ registry_username }}" -p "{{ registry_token }}" https://{{ registry_url }}
-    when: registry_username != ""
-
-  - name: Pull CoreDNS container
-    raw: podman pull --tls-verify=false {{ registry_url }}/coredns:{{ image_tag }}
-
-  - name: Enable coredns.service
-    raw: sudo systemctl stop coredns.service; sudo systemctl daemon-reload; sudo systemctl enable coredns.service; sudo systemctl start coredns.service
+      dest: /etc/coredns/Corefile
+      force: no  
 
 - hosts: svcs, asvcs, csvcs, esvcs
   tasks:
@@ -181,3 +77,16 @@
       permanent: yes
       immediate: yes
       state: enabled
+
+
+- hosts: svcs, asvcs, csvcs, esvcs
+  any_errors_fatal: true
+  strategy: linear
+  serial: 1
+  tasks:
+  - name: Enable and (re)start coredns.service
+    systemd:
+      name: coredns
+      state: restarted
+      enabled: yes
+      daemon_reload: yes

--- a/upi/vsphere/stage2/8.configure-svcs/playbooks/configure_svc_dns.yaml
+++ b/upi/vsphere/stage2/8.configure-svcs/playbooks/configure_svc_dns.yaml
@@ -16,6 +16,13 @@
       src: templates/coredns.service.j2
       dest: /etc/systemd/system/coredns.service
 
+  - name: Login to registry to pull image
+    raw: podman login --tls-verify=false  -u "{{ registry_username }}" -p "{{ registry_token }}" https://{{ registry_url }}
+    when: registry_username != ""
+
+  - name: Pull CoreDNS container
+    raw: podman pull --tls-verify=false {{ registry_url }}/coredns:{{ image_tag }}
+      
 - hosts: svcs
   vars:
     dns_server1: "{{ man_dns_server1 }}"
@@ -83,14 +90,9 @@
   strategy: linear
   serial: 1
   tasks:
-  - name: Enable (and stop, if necessary) coredns.service
+  - name: Enable (and restart) coredns.service
     systemd:
       name: coredns
-      state: stopped
+      state: restarted
       enabled: yes
       daemon_reload: yes
-
-  - name: Start coredns.service
-    systemd:
-      name: coredns
-      state: started

--- a/upi/vsphere/stage2/8.configure-svcs/playbooks/configure_svc_dns.yaml
+++ b/upi/vsphere/stage2/8.configure-svcs/playbooks/configure_svc_dns.yaml
@@ -83,7 +83,7 @@
   strategy: linear
   serial: 1
   tasks:
-  - name: Enable coredns.service
+  - name: Enable (and stop, if necessary) coredns.service
     systemd:
       name: coredns
       state: stopped
@@ -93,5 +93,4 @@
   - name: Start coredns.service
     systemd:
       name: coredns
-      enabled: yes
       state: started

--- a/upi/vsphere/stage2/8.configure-svcs/playbooks/configure_svc_dns.yaml
+++ b/upi/vsphere/stage2/8.configure-svcs/playbooks/configure_svc_dns.yaml
@@ -78,15 +78,20 @@
       immediate: yes
       state: enabled
 
-
 - hosts: svcs, asvcs, csvcs, esvcs
   any_errors_fatal: true
   strategy: linear
   serial: 1
   tasks:
-  - name: Enable and (re)start coredns.service
+  - name: Enable coredns.service
     systemd:
       name: coredns
-      state: restarted
+      state: stopped
       enabled: yes
       daemon_reload: yes
+
+  - name: Start coredns.service
+    systemd:
+      name: coredns
+      enabled: yes
+      state: started

--- a/upi/vsphere/stage2/8.configure-svcs/playbooks/templates/coredns.service.j2
+++ b/upi/vsphere/stage2/8.configure-svcs/playbooks/templates/coredns.service.j2
@@ -4,7 +4,7 @@ Wants=crio.service
 [Service]
 Restart=always
 RestartSec=1
-ExecStartPre=-/usr/bin/podman stop coredns
+ExecStartPre=-/usr/bin/podman rm coredns --storage -f
 ExecStart=/usr/bin/podman run --rm=true -a=STDOUT --name coredns -v /etc/coredns:/etc/coredns:z --network host -p 53:53/udp {{ registry_url }}/coredns:{{ image_tag }} --conf /etc/coredns/Corefile
 ExecStop=/usr/bin/podman stop coredns
 [Install]

--- a/upi/vsphere/stage2/8.configure-svcs/playbooks/templates/coredns.service.j2
+++ b/upi/vsphere/stage2/8.configure-svcs/playbooks/templates/coredns.service.j2
@@ -4,8 +4,8 @@ Wants=crio.service
 [Service]
 Restart=always
 RestartSec=5
-ExecStartPre=-/usr/bin/podman stop coredns
+ExecStartPre=/bin/sleep 3
 ExecStart=/usr/bin/podman run --rm=true -a=STDOUT --name coredns --read-only -v /etc/coredns:/etc/coredns:ro,noexec --network host -p 53:53/udp {{ registry_url }}/coredns:{{ image_tag }} --conf /etc/coredns/Corefile
-ExecStop=/usr/bin/podman stop coredns
+ExecStop=/usr/bin/podman kill --signal SIGQUIT coredns
 [Install]
 WantedBy=multi-user.target

--- a/upi/vsphere/stage2/8.configure-svcs/playbooks/templates/coredns.service.j2
+++ b/upi/vsphere/stage2/8.configure-svcs/playbooks/templates/coredns.service.j2
@@ -5,7 +5,7 @@ Wants=crio.service
 Restart=always
 RestartSec=5
 ExecStartPre=-/usr/bin/podman stop coredns
-ExecStart=/usr/bin/podman run --rm=true -a=STDOUT --name coredns -v /etc/coredns:/etc/coredns:z --network host -p 53:53/udp {{ registry_url }}/coredns:{{ image_tag }} --conf /etc/coredns/Corefile
+ExecStart=/usr/bin/podman run --rm=true -a=STDOUT --name coredns --read-only -v /etc/coredns:/etc/coredns:ro,noexec --network host -p 53:53/udp {{ registry_url }}/coredns:{{ image_tag }} --conf /etc/coredns/Corefile
 ExecStop=/usr/bin/podman stop coredns
 [Install]
 WantedBy=multi-user.target

--- a/upi/vsphere/stage2/8.configure-svcs/playbooks/templates/coredns.service.j2
+++ b/upi/vsphere/stage2/8.configure-svcs/playbooks/templates/coredns.service.j2
@@ -3,7 +3,7 @@ Description=CoreDNS container
 Wants=crio.service
 [Service]
 Restart=always
-RestartSec=1
+RestartSec=5
 ExecStartPre=-/usr/bin/podman stop coredns
 ExecStart=/usr/bin/podman run --rm=true -a=STDOUT --name coredns -v /etc/coredns:/etc/coredns:z --network host -p 53:53/udp {{ registry_url }}/coredns:{{ image_tag }} --conf /etc/coredns/Corefile
 ExecStop=/usr/bin/podman stop coredns

--- a/upi/vsphere/stage2/8.configure-svcs/playbooks/templates/coredns.service.j2
+++ b/upi/vsphere/stage2/8.configure-svcs/playbooks/templates/coredns.service.j2
@@ -4,7 +4,7 @@ Wants=crio.service
 [Service]
 Restart=always
 RestartSec=1
-ExecStartPre=-/usr/bin/podman rm coredns --storage -f
+ExecStartPre=-/usr/bin/podman stop coredns
 ExecStart=/usr/bin/podman run --rm=true -a=STDOUT --name coredns -v /etc/coredns:/etc/coredns:z --network host -p 53:53/udp {{ registry_url }}/coredns:{{ image_tag }} --conf /etc/coredns/Corefile
 ExecStop=/usr/bin/podman stop coredns
 [Install]


### PR DESCRIPTION
This container used to use a load of nasty raw commands so it could target RHCOS VMs. We now use RHEL in the svc role so this moves it to (mostly) use proper ansible.

- Update Ansible runner to latest
- Podman login/pull commands remain as raw command because it works, and avoids some unpleasant conditionals to handle anon and authenticated pull that would be needed with the podman module
- Revise systemd service unit file so it uses kill SIGQUIT rather than stop: seems to prevent the problem where it fails to restart. ExecStartPre sleep ensures that it has enough time to fully quit and destroy the container when the service is restarted.


Tested with CoreDNS 1.7 and 1.8 in dev environment. Will be moved into (and tested in) preprod after review.