### PR TITLE
Project Isolation NetworkPolicy

### DIFF
--- a/post-deployment/openstack/networkpolicy.yml
+++ b/post-deployment/openstack/networkpolicy.yml
@@ -37,7 +37,7 @@
         - apiVersion: networking.k8s.io/v1
           kind: NetworkPolicy
           metadata:
-            name: allow-same-namespace
+            name: allow-from-same-namespace
             namespace: ${PROJECT_NAME}
           spec:
             ingress:
@@ -65,7 +65,7 @@
         - name: PROJECT_ADMIN_USER
         - name: PROJECT_REQUESTING_USER
 
-  - name: Configure the cluster to use the Project template
+  - name: Configure the cluster to use the project template
     k8s:
       state: present
       definition:

--- a/post-deployment/openstack/networkpolicy.yml
+++ b/post-deployment/openstack/networkpolicy.yml
@@ -1,0 +1,78 @@
+---
+- hosts: localhost
+  
+  tasks:
+  - name: Label default namespace to allow NetworkPolicy to work
+    k8s:
+      state: present
+      definition:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: default
+          labels:
+            network.openshift.io/policy-group: "ingress"
+
+  - name: Create a default project template which includes NetworkPolicy
+    k8s:
+      state: present
+      definition:
+        apiVersion: template.openshift.io/v1
+        kind: Template
+        metadata:
+          name: project-defaults
+          namespace: openshift-config
+        objects:
+        - apiVersion: project.openshift.io/v1
+          kind: Project
+          metadata:
+            annotations:
+              openshift.io/description: ${PROJECT_DESCRIPTION}
+              openshift.io/display-name: ${PROJECT_DISPLAYNAME}
+              openshift.io/requester: ${PROJECT_REQUESTING_USER}
+            creationTimestamp: null
+            name: ${PROJECT_NAME}
+          spec: {}
+          status: {}
+        - apiVersion: networking.k8s.io/v1
+          kind: NetworkPolicy
+          metadata:
+            name: allow-same-namespace
+            namespace: ${PROJECT_NAME}
+          spec:
+            ingress:
+            - from:
+              - podSelector: {}
+            podSelector: null
+        - apiVersion: networking.k8s.io/v1
+          kind: NetworkPolicy
+          metadata:
+            name: allow-from-ingress-routers
+            namespace: ${PROJECT_NAME}
+          spec:
+            ingress:
+            - from:
+              - namespaceSelector:
+                  matchLabels:
+                    network.openshift.io/policy-group: ingress
+            podSelector: {}
+            policyTypes:
+            - Ingress
+        parameters:
+        - name: PROJECT_NAME
+        - name: PROJECT_DISPLAYNAME
+        - name: PROJECT_DESCRIPTION
+        - name: PROJECT_ADMIN_USER
+        - name: PROJECT_REQUESTING_USER
+
+  - name: Configure the cluster to use the Project template
+    k8s:
+      state: present
+      definition:
+        apiVersion: config.openshift.io/v1
+        kind: Project
+        metadata:
+          name: cluster
+        spec:
+          projectRequestTemplate:
+            name: project-defaults  

--- a/post-deployment/openstack/post-deployment.yml
+++ b/post-deployment/openstack/post-deployment.yml
@@ -23,6 +23,8 @@
   when: useSingleSignOn | default(true) | bool
 - import_playbook: ingress.yml
   when: useLetsEncryptCert | default(true) | bool
+- import_playbook: networkpolicy.yml
+  when: isolateProjectsNetworkPolicy | default(true) | bool  
 - import_playbook: monitoring-sa.yml
 - import_playbook: acme-sa.yml
   when: useLetsEncryptCert | default(true) | bool

--- a/post-deployment/openstack/vars.yml
+++ b/post-deployment/openstack/vars.yml
@@ -14,10 +14,13 @@ secretKey: <secret key>
 logging: <boolean>
 # Opsview host name format cnaxxxxx-<customer>
 opsviewName: <name>
-## Set to false when using default kubeadmin user, defaults to true
+## Set to false to use default kubeadmin user auth, defaults to true:
 #useSingleSignOn: false
-## Set to false when using self-signed certificates, defaults to true
+## Set to false when using self-signed certificates, defaults to true:
 #useLetsEncryptCert: false
+## Set to fales to disable isolation NetworkPolicy being added to 
+## default project template to prevent inter-project comms, defaults to true:
+#isolateProjectsNetworkPolicy: false
 # DNS Forwarding - omit or set to {} to disable
 dnsforwardingzones: 
   - name: foo-dns

--- a/post-deployment/openstack/vars.yml
+++ b/post-deployment/openstack/vars.yml
@@ -18,7 +18,7 @@ opsviewName: <name>
 #useSingleSignOn: false
 ## Set to false when using self-signed certificates, defaults to true:
 #useLetsEncryptCert: false
-## Set to fales to disable isolation NetworkPolicy being added to 
+## Set to false to disable isolation NetworkPolicy being added to 
 ## default project template to prevent inter-project comms, defaults to true:
 #isolateProjectsNetworkPolicy: false
 # DNS Forwarding - omit or set to {} to disable

--- a/post-deployment/openstack/vars.yml
+++ b/post-deployment/openstack/vars.yml
@@ -18,8 +18,8 @@ opsviewName: <name>
 #useSingleSignOn: false
 ## Set to false when using self-signed certificates, defaults to true:
 #useLetsEncryptCert: false
-## Set to false to disable isolation NetworkPolicy being added to 
-## default project template to prevent inter-project comms, defaults to true:
+## Set to false to prevent isolation NetworkPolicy's being added to 
+## default project template, defaults to true:
 #isolateProjectsNetworkPolicy: false
 # DNS Forwarding - omit or set to {} to disable
 dnsforwardingzones: 


### PR DESCRIPTION
Adds a default project template which means that projects made with `oc new-project` or the webUI will have NetworkPolicy objects that allows inbound traffic only from the same project or from ingress via routes.

If required, `isolateProjectsNetworkPolicy` can be set to False in `vars.yml` to prevent the playbook running, leaving the default behaviour of all pod/svc IPs being accessible from all projects.

Doesn't affect existing `openshift-*` projects, or projects/namespaces manually created with yaml (including all known namespaces created by OLM for operator install).

Reconfiguring the project template in use causes `openshift-apiserver` clusteroperator to deploy a new revision (non-impacting but takes a couple of mins)