### PR TITLE
Change TTL for cluster zonefile to 6hrs

### DIFF
--- a/upi/vsphere/stage2/8.configure-svcs/playbooks/templates/zonefile.j2
+++ b/upi/vsphere/stage2/8.configure-svcs/playbooks/templates/zonefile.j2
@@ -1,5 +1,5 @@
 $ORIGIN {{ domain_suffix }}.
-$TTL 60s
+$TTL 6h
 @    IN    SOA    dns1.{{ domain_suffix }}.    hostmaster.{{ domain_suffix }}. (
             {{ ansible_date_time.epoch }} ; serial
             21600      ; refresh after 6 hours


### PR DESCRIPTION
Tiny change to alter the cluster zone file from 60secs to 6 hours.

Tested in Preprod; no ill effects. This change is needed in the deploy container because it is reran during cluster scaling, overwriting the zone file. Only affects the names inside the zone file (not forwarded lookups, obvs).