### PR TITLE
Net2 ingress

### DIFF
--- a/post-deployment/openstack/net2-ingress/build/Dockerfile
+++ b/post-deployment/openstack/net2-ingress/build/Dockerfile
@@ -1,5 +1,5 @@
 # FROM ansible-runner:latest
-FROM docker.io/ansible/ansible-runner@sha256:
+FROM docker.io/ansible/ansible-runner@sha256:bd09ef403f2f90f2c6bd133d7533e939058903f69223c5f12557a49e3aed14bb
 
 WORKDIR /usr/local/
 
@@ -15,5 +15,4 @@ RUN pip3 install --upgrade pip && \
 # Install Ansible collections for Kubernetes/Openstack modules
 RUN ansible-galaxy collection install -r ./ansible-requirements.yml
 
-# 
 ENTRYPOINT ./entrypoint.sh

--- a/post-deployment/openstack/net2-ingress/build/Dockerfile
+++ b/post-deployment/openstack/net2-ingress/build/Dockerfile
@@ -1,18 +1,18 @@
 # FROM ansible-runner:latest
-FROM docker.io/ansible/ansible-runner@sha256:bd09ef403f2f90f2c6bd133d7533e939058903f69223c5f12557a49e3aed14bb
+FROM docker.io/ansible/ansible-runner@sha256:4c6034798b5e724c5a59466f5438e14480c53bc4adac5cc9db5e3997a286a0e4
 
 WORKDIR /usr/local/
 
-ADD ./playbooks ./playbooks
-COPY ./pip-requirements.txt ./pip-requirements.txt
-COPY ./ansible-requirements.yml ./ansible-requirements.yml
+ADD ./playbooks /usr/local/playbooks
+COPY ./pip-requirements.txt /usr/local/pip-requirements.txt
+COPY ./ansible-requirements.yml /usr/local/ansible-requirements.yml
 
 # Upgrade pip and install requirements for Kubernetes/Openstack modules
 RUN pip3 install --upgrade pip && \
     pip3 install -U setuptools && \
-    pip3 install -r ./pip-requirements.txt
+    pip3 install -r /usr/local/pip-requirements.txt --ignore-installed PyYAML
 
 # Install Ansible collections for Kubernetes/Openstack modules
-RUN ansible-galaxy collection install -r ./ansible-requirements.yml
+RUN ansible-galaxy collection install -r /usr/local/ansible-requirements.yml
 
-ENTRYPOINT ./entrypoint.sh
+ENTRYPOINT /usr/local/playbooks/entrypoint.sh

--- a/post-deployment/openstack/net2-ingress/build/Dockerfile
+++ b/post-deployment/openstack/net2-ingress/build/Dockerfile
@@ -1,0 +1,19 @@
+# FROM ansible-runner:latest
+FROM docker.io/ansible/ansible-runner@sha256:
+
+WORKDIR /usr/local/
+
+ADD ./playbooks ./playbooks
+COPY ./pip-requirements.txt ./pip-requirements.txt
+COPY ./ansible-requirements.yml ./ansible-requirements.yml
+
+# Upgrade pip and install requirements for Kubernetes/Openstack modules
+RUN pip3 install --upgrade pip && \
+    pip3 install -U setuptools && \
+    pip3 install -r ./pip-requirements.txt
+
+# Install Ansible collections for Kubernetes/Openstack modules
+RUN ansible-galaxy collection install -r ./ansible-requirements.yml
+
+# 
+ENTRYPOINT ./entrypoint.sh

--- a/post-deployment/openstack/net2-ingress/build/ansible-requirements.yml
+++ b/post-deployment/openstack/net2-ingress/build/ansible-requirements.yml
@@ -1,0 +1,6 @@
+---
+collections:
+- name: openstack.cloud
+  version: "1.2.0"
+- name: community.kubernetes
+  version: "1.2.0"

--- a/post-deployment/openstack/net2-ingress/build/pip-requirements.txt
+++ b/post-deployment/openstack/net2-ingress/build/pip-requirements.txt
@@ -1,0 +1,4 @@
+openshift~=0.6
+PyYAML~=3.11
+jmespath
+openstacksdk~=0.12.0

--- a/post-deployment/openstack/net2-ingress/build/pip-requirements.txt
+++ b/post-deployment/openstack/net2-ingress/build/pip-requirements.txt
@@ -1,4 +1,6 @@
-openshift~=0.6
-PyYAML~=3.11
-jmespath
-openstacksdk~=0.12.0
+openshift~=0.12.0
+PyYAML~=5.4.1
+jmespath~=0.10.0
+openstacksdk~=0.56.0
+python-octaviaclient~=2.3.0
+python-openstackclient~=5.5.0

--- a/post-deployment/openstack/net2-ingress/build/playbooks/entrypoint.sh
+++ b/post-deployment/openstack/net2-ingress/build/playbooks/entrypoint.sh
@@ -1,0 +1,2 @@
+export K8S_AUTH_VERIFY_SSL=no
+ansible-playbook /usr/local/playbooks/update_loadbalancer_members.yaml

--- a/post-deployment/openstack/net2-ingress/build/playbooks/entrypoint.sh
+++ b/post-deployment/openstack/net2-ingress/build/playbooks/entrypoint.sh
@@ -1,2 +1,10 @@
 export K8S_AUTH_VERIFY_SSL=no
+
+# Add uid to /etc/passwd to allow Ansible to run
+if [ `id -u` -ge 500 ]; then
+    echo "runner:x:`id -u`:`id -g`:,,,:/runner:/bin/bash" > /tmp/passwd
+    cat /tmp/passwd >> /etc/passwd
+    rm /tmp/passwd
+fi
+
 ansible-playbook /usr/local/playbooks/update_loadbalancer_members.yaml

--- a/post-deployment/openstack/net2-ingress/build/playbooks/update_loadbalancer_members.yaml
+++ b/post-deployment/openstack/net2-ingress/build/playbooks/update_loadbalancer_members.yaml
@@ -44,13 +44,17 @@
     set_fact:
       loadbalancerMembersToAdd: "{{ loadbalancerMembersToAdd | default([]) + [ item ] }}"
     with_items: "{{ net2Members }}"
-    when: item not in loadbalancerMembers
+    when: 
+      - net2Members is defined
+      - item not in loadbalancerMembers
 
   - name: 'Determine members to be deleted'
     set_fact:
       loadbalancerMembersToDelete: "{{ loadbalancerMembersToDelete | default([]) + [ item ] }}"
     with_items: "{{ loadbalancerMembers }}"
-    when: item not in net2Members
+    when: 
+      - net2Members is defined
+      - item not in net2Members
 
   - name: 'Add loadbalancer members'
     openstack.cloud.lb_member:

--- a/post-deployment/openstack/net2-ingress/build/playbooks/update_loadbalancer_members.yaml
+++ b/post-deployment/openstack/net2-ingress/build/playbooks/update_loadbalancer_members.yaml
@@ -1,0 +1,75 @@
+---
+- hosts: localhost
+  connection: local
+  gather_facts: no
+
+  tasks:
+  - name: 'Get net2 nodes'
+    community.kubernetes.k8s_info:
+      kind: Node
+      label_selectors:
+        - node-role.kubernetes.io/net2 =
+    register: net2Nodes
+
+  - name: 'Extract net2 node IPs'
+    set_fact:
+      net2MembersRaw: "{{ net2Nodes | to_json | from_json | json_query(net2MembersRawQuery) }}"
+    vars:
+      net2MembersRawQuery: "resources[*].status.addresses[?type=='InternalIP'].address"
+
+  - name: 'Build net2 node IP dict'
+    set_fact:
+      net2Members: "{{ net2Members | default([]) + [ item ] }}"
+    with_items: "{{ net2MembersRaw }}"
+
+  - name: 'Get loadbalancer pools'
+    command:
+      cmd: openstack loadbalancer pool list -c name -f value
+    register: loadbalancerPoolsRaw
+
+  - name: Sanitise loadbalancer pools
+    set_fact:
+      loadbalancerPools: "{{ loadbalancerPoolsRaw.stdout_lines }}"
+
+  - name: 'Get loadbalancer pool members'
+    command:
+      cmd: openstack loadbalancer member list "{{ loadbalancerPools | first }}" -c address -f value
+    register: loadbalancerMembersRaw
+
+  - name: 'Sanitise loadbalancer pool members'
+    set_fact:
+      loadbalancerMembers: "{{ loadbalancerMembersRaw.stdout_lines }}"
+
+  - name: 'Determine members to be added'
+    set_fact:
+      loadbalancerMembersToAdd: "{{ loadbalancerMembersToAdd | default([]) + [ item ] }}"
+    with_items: "{{ net2Members }}"
+    when: item not in loadbalancerMembers
+
+  - name: 'Determine members to be deleted'
+    set_fact:
+      loadbalancerMembersToDelete: "{{ loadbalancerMembersToDelete | default([]) + [ item ] }}"
+    with_items: "{{ loadbalancerMembers }}"
+    when: item not in net2Members
+
+  - name: 'Add loadbalancer members'
+    openstack.cloud.lb_member:
+      name: "{{ item[1] }}"
+      address: "{{ item[1] }}"
+      pool: "{{ item[0] }}"
+      protocol_port: "{{ 443 if '-HTTPS-' in item[0] else 80 }}"
+      state: present
+    with_nested:
+      - "{{ loadbalancerPools }}"
+      - "{{ loadbalancerMembersToAdd }}"
+    when: loadbalancerMembersToAdd is defined
+
+  - name: 'Delete loadbalancer members'
+    openstack.cloud.lb_member:
+      name: "{{ item[1] }}"
+      pool: "{{ item[0] }}"
+      state: absent
+    with_nested:
+      - "{{ loadbalancerPools }}"
+      - "{{ loadbalancerMembersToDelete }}"
+    when: loadbalancerMembersToDelete is defined

--- a/post-deployment/openstack/net2-ingress/build/playbooks/update_loadbalancer_members.yaml
+++ b/post-deployment/openstack/net2-ingress/build/playbooks/update_loadbalancer_members.yaml
@@ -4,6 +4,24 @@
   gather_facts: no
 
   tasks:
+  - name: 'Retrieve OpenStack secret'
+    community.kubernetes.k8s_info:
+      kind: Secret
+      name: openstack-credentials
+      namespace: kube-system
+    register: openstackCredentialRaw
+
+  - name: 'Extract OpenStack credential'
+    ansible.builtin.set_fact:
+      openstackCredential: "{{ openstackCredentialRaw | to_json | from_json | json_query(openstackCredentialQuery) }}"
+    vars:
+      openstackCredentialQuery: 'resources[0].data."clouds.yaml"'
+
+  - name: 'Write OpenStack credential to file'
+    ansible.builtin.copy:
+      dest: /etc/openstack/clouds.yaml
+      content: "{{ openstackCredential | b64decode }}"
+
   - name: 'Get net2 nodes'
     community.kubernetes.k8s_info:
       kind: Node
@@ -12,36 +30,34 @@
     register: net2Nodes
 
   - name: 'Extract net2 node IPs'
-    set_fact:
+    ansible.builtin.set_fact:
       net2MembersRaw: "{{ net2Nodes | to_json | from_json | json_query(net2MembersRawQuery) }}"
     vars:
       net2MembersRawQuery: "resources[*].status.addresses[?type=='InternalIP'].address"
 
   - name: 'Build net2 node IP dict'
-    set_fact:
+    ansible.builtin.set_fact:
       net2Members: "{{ net2Members | default([]) + [ item ] }}"
     with_items: "{{ net2MembersRaw }}"
 
   - name: 'Get loadbalancer pools'
-    command:
-      cmd: openstack loadbalancer pool list -c name -f value
+    ansible.builtin.command: openstack loadbalancer pool list -c name -f value
     register: loadbalancerPoolsRaw
 
   - name: Sanitise loadbalancer pools
-    set_fact:
+    ansible.builtin.set_fact:
       loadbalancerPools: "{{ loadbalancerPoolsRaw.stdout_lines }}"
 
   - name: 'Get loadbalancer pool members'
-    command:
-      cmd: openstack loadbalancer member list "{{ loadbalancerPools | first }}" -c address -f value
+    ansible.builtin.command: openstack loadbalancer member list "{{ loadbalancerPools | first }}" -c address -f value
     register: loadbalancerMembersRaw
 
   - name: 'Sanitise loadbalancer pool members'
-    set_fact:
+    ansible.builtin.set_fact:
       loadbalancerMembers: "{{ loadbalancerMembersRaw.stdout_lines }}"
 
   - name: 'Determine members to be added'
-    set_fact:
+    ansible.builtin.set_fact:
       loadbalancerMembersToAdd: "{{ loadbalancerMembersToAdd | default([]) + [ item ] }}"
     with_items: "{{ net2Members }}"
     when: 
@@ -49,7 +65,7 @@
       - item not in loadbalancerMembers
 
   - name: 'Determine members to be deleted'
-    set_fact:
+    ansible.builtin.set_fact:
       loadbalancerMembersToDelete: "{{ loadbalancerMembersToDelete | default([]) + [ item ] }}"
     with_items: "{{ loadbalancerMembers }}"
     when: 

--- a/post-deployment/openstack/net2-ingress/main.yml
+++ b/post-deployment/openstack/net2-ingress/main.yml
@@ -1,0 +1,46 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars:
+    namespace: "net2-ingress"
+
+  tasks:
+  - name: "Create {{ namespace }} namespace"
+    k8s:
+      state: present
+      definition:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: "{{ namespace }}"
+
+  - name: Create secret containing sa token
+    k8s:
+      state: present
+      definition:
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: "net2-ingress-sa"
+          namespace: "{{ namespace }}"
+        data:
+          token: "{{ net2IngressSaToken | b64encode }}"
+
+  - name: Create build
+    command: "oc new-build --binary --strategy=docker --name update-loadbalancer-members -n {{ namespace }}"
+    args:
+      chdir: "./build"
+
+  - name: Start build
+    command: "oc start-build update-loadbalancer-members --from-dir . -F -n {{ namespace }}"
+    args:
+      chdir: "./build"
+
+  - name: Allow imagestream lookups from same project
+    command: "oc set image-lookup update-loadbalancer-members -n {{ namespace }}"
+
+  - name: Create update-loadbalancer-members CronJob
+    k8s:
+      state: present
+      definition: "{{ lookup('template', 'templates/cronjob-update-loadbalancer-members.j2') }}"

--- a/post-deployment/openstack/net2-ingress/main.yml
+++ b/post-deployment/openstack/net2-ingress/main.yml
@@ -28,18 +28,60 @@
         data:
           token: "{{ net2IngressSaToken | b64encode }}"
 
-  - name: Create build
-    command: "oc new-build --binary --strategy=docker --name update-loadbalancer-members -n {{ namespace }}"
-    args:
-      chdir: "./build"
+  - name: Create ImageStream
+    k8s:
+      state: present
+      definition:
+        apiVersion: image.openshift.io/v1
+        kind: ImageStream
+        metadata:
+          name: update-loadbalancer-members
+          namespace: "{{ namespace }}"
+        spec:
+          lookupPolicy:
+            local: true
 
-  - name: Start build
+  - name: Create BuildConfig
+    k8s:
+      state: present
+      definition:
+        apiVersion: build.openshift.io/v1
+        kind: BuildConfig
+        metadata:
+          labels:
+            build: update-loadbalancer-members
+          name: update-loadbalancer-members
+          namespace: "{{ namespace }}"
+        spec:
+          nodeSelector:
+            node-role.kubernetes.io/infra:
+          output:
+            to:
+              kind: ImageStreamTag
+              name: update-loadbalancer-members:latest
+          source:
+            binary: {}
+            type: Binary
+          strategy:
+            dockerStrategy: {}
+            type: Docker
+
+  - name: Run Docker build
     command: "oc start-build update-loadbalancer-members --from-dir . -F -n {{ namespace }}"
     args:
       chdir: "./build"
+    register: buildStatus
+    failed_when: "'Push successful' not in buildStatus.stdout_lines"
 
-  - name: Allow imagestream lookups from same project
-    command: "oc set image-lookup update-loadbalancer-members -n {{ namespace }}"
+  - name: Delete BuildConfig
+    k8s:
+      state: absent
+      definition:
+        apiVersion: build.openshift.io/v1
+        kind: BuildConfig
+        metadata:
+          name: update-loadbalancer-members
+          namespace: "{{ namespace }}"
 
   - name: Create update-loadbalancer-members CronJob
     k8s:
@@ -49,4 +91,22 @@
   - name: Create IngressController
     k8s:
       state: present
-      definition: "{{ lookup('template', 'templates/ingress-controller.j2') }}"
+      definition:
+        apiVersion: operator.openshift.io/v1
+        kind: IngressController
+        metadata:
+          namespace: openshift-ingress-operator
+          name: "{{ net2NetworkName | replace('_','-') }}"
+        spec:
+          domain: "{{ net2NetworkName | replace('_','-') }}.{{ domainSuffix }}"
+          nodePlacement:
+            nodeSelector:
+              matchLabels:
+                network: "{{ net2NetworkName }}"
+          replicas: 2
+          routeSelector:
+            matchExpressions:
+            - key: network
+              operator: In
+              values:
+              - "{{ net2NetworkName }}"

--- a/post-deployment/openstack/net2-ingress/main.yml
+++ b/post-deployment/openstack/net2-ingress/main.yml
@@ -4,6 +4,7 @@
 
   vars:
     namespace: "net2-ingress"
+    net2NetworkName: "{{ net2ExternalNetwork | lower }}"
 
   tasks:
   - name: "Create {{ namespace }} namespace"
@@ -44,3 +45,8 @@
     k8s:
       state: present
       definition: "{{ lookup('template', 'templates/cronjob-update-loadbalancer-members.j2') }}"
+
+  - name: Create IngressController
+    k8s:
+      state: present
+      definition: "{{ lookup('template', 'templates/ingress-controller.j2') }}"

--- a/post-deployment/openstack/net2-ingress/sa.yml
+++ b/post-deployment/openstack/net2-ingress/sa.yml
@@ -1,5 +1,7 @@
 ---
 - hosts: localhost
+  connection: local
+  gather_facts: false
 
   vars:
     secrets:

--- a/post-deployment/openstack/net2-ingress/templates/cronjob-update-loadbalancer-members.j2
+++ b/post-deployment/openstack/net2-ingress/templates/cronjob-update-loadbalancer-members.j2
@@ -1,0 +1,35 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: "update-loadbalancer-members"
+  namespace: "{{ namespace }}"
+spec:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: "Replace"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        spec:
+          containers:
+          - name: update-loadbalancer-members
+            image: update-loadbalancer-members
+            env:
+            - name: K8S_AUTH_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "net2-ingress-sa"
+                  key: token
+            - name: K8S_AUTH_HOST
+              value: "https://api.{{ domainSuffix}}:6443"
+            - name: OS_CLOUD
+              value: openstack
+            volumeMounts:
+            - mountPath: "/etc/openstack"
+              name: clouds
+          volumes:
+            - name: clouds
+              emptyDir: {}
+          restartPolicy: Never

--- a/post-deployment/openstack/net2ingress-sa.yml
+++ b/post-deployment/openstack/net2ingress-sa.yml
@@ -1,0 +1,107 @@
+---
+- hosts: localhost
+
+  vars:
+    secrets:
+      - name: "openstack-credentials"
+        namespace: "kube-system"
+
+  tasks:
+  - name: 'Create net2-ingress service account'
+    k8s:
+      state: present
+      definition:
+        apiVersion: v1
+        kind: ServiceAccount
+        metadata:
+          name: net2-ingress
+          namespace: default
+
+  - name: 'Create net2-ingress roles'
+    k8s:
+      state: present
+      definition:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: Role
+        metadata:
+          name: net2-ingress
+          namespace: "{{ item.namespace }}"
+        rules:
+        - apiGroups: [""]
+          resources: ["secrets"]
+          resourceNames: ["{{ item.name }}"]
+          verbs:
+          - get
+          - list
+          - watch
+    with_items: "{{ secrets }}"
+
+  - name: 'Create net2-ingress rolebindings'
+    k8s:
+      state: present
+      definition:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        metadata:
+          name: "net2-ingress"
+          namespace: "{{ item.namespace }}"
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: Role
+          name: net2-ingress
+        subjects:
+        - kind: ServiceAccount
+          name: net2-ingress
+          namespace: default
+    with_items: "{{ secrets }}"
+
+  - name: 'Create node-reader ClusterRole'
+    k8s:
+      state: present
+      definition:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        metadata:
+          name: node-reader
+        rules:
+          - apiGroups:
+            - ""
+            resources:
+            - nodes
+            verbs:
+            - get
+            - list
+            - watch
+
+  - name: 'Create net2-ingress-node-reader clusterrolebinding'
+    k8s:
+      state: present
+      definition:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        metadata:
+          name: "net2-ingress-node-reader"
+        roleRef:
+          apiGroup: ""
+          kind: ClusterRole
+          name: node-reader
+        subjects:
+        - kind: ServiceAccount
+          name: net2-ingress
+          namespace: default
+
+  - name: 'Retrieve net2-ingress token'
+    command: oc serviceaccounts get-token net2-ingress -n default
+    register: net2IngressToken
+
+  - name: 'Write token to variable'
+    set_fact:
+      net2IngressSaToken: "{{ net2IngressToken.stdout }}"
+
+  - name: 'Verify token'
+    uri:
+      url: "https://api.{{ domainSuffix }}:6443/api/v1"
+      return_content: yes
+      validate_certs: no
+      headers:
+        Authorization: "Bearer {{ net2IngressSaToken }}"

--- a/post-deployment/openstack/pip-requirements.txt
+++ b/post-deployment/openstack/pip-requirements.txt
@@ -2,4 +2,3 @@ ansible>=2.9,<3
 jmespath>=0.10
 openshift>=0.11
 PyYAML>=5.3
-

--- a/post-deployment/openstack/post-deployment.yml
+++ b/post-deployment/openstack/post-deployment.yml
@@ -26,3 +26,7 @@
 - import_playbook: monitoring-sa.yml
 - import_playbook: acme-sa.yml
   when: useLetsEncryptCert | default(true) | bool
+- import_playbook: net2-ingress/sa.yml
+  when: net2 | default(false) | bool
+- import_playbook: net2-ingress/main.yml
+  when: net2 | default(false) | bool

--- a/post-deployment/openstack/vars.yml
+++ b/post-deployment/openstack/vars.yml
@@ -18,6 +18,8 @@ opsviewName: <name>
 #useSingleSignOn: false
 ## Set to false when using self-signed certificates, defaults to true
 #useLetsEncryptCert: false
+## Set to true when deploying net2, defaults to false
+#net2: true
 # DNS Forwarding - omit or set to {} to disable
 dnsforwardingzones: 
   - name: foo-dns

--- a/post-deployment/openstack/vars.yml
+++ b/post-deployment/openstack/vars.yml
@@ -20,6 +20,7 @@ opsviewName: <name>
 #useLetsEncryptCert: false
 ## Set to true when deploying net2, defaults to false
 #net2: true
+#net2ExternalNetwork:  <net2 external network>
 # DNS Forwarding - omit or set to {} to disable
 dnsforwardingzones: 
   - name: foo-dns


### PR DESCRIPTION
Builds an ansible-runner image (and supporting objects) which updates OpenStack Octavia members (backends) in order to facilitate ingress traffic to a Net2 OpenShift cluster.

The image is referenced by a Cronjob which runs every 5 minutes which ensures minimal disruption to ingress traffic when scaling net2 nodes.