### PR TITLE
Add DNS function tests to 8.configure-svcs

### DIFF
--- a/upi/vsphere/stage2/8.configure-svcs/Dockerfile
+++ b/upi/vsphere/stage2/8.configure-svcs/Dockerfile
@@ -1,4 +1,5 @@
 FROM docker.io/ansible/ansible-runner@sha256:bd09ef403f2f90f2c6bd133d7533e939058903f69223c5f12557a49e3aed14bb
 ADD ./playbooks /usr/local/playbooks
+RUN yum install -y bind-utils; yum clean all
 WORKDIR /tmp/workingdir
 ENTRYPOINT /usr/local/playbooks/entrypoint.sh

--- a/upi/vsphere/stage2/8.configure-svcs/playbooks/configure_svc_dns.yaml
+++ b/upi/vsphere/stage2/8.configure-svcs/playbooks/configure_svc_dns.yaml
@@ -96,3 +96,15 @@
       state: restarted
       enabled: yes
       daemon_reload: yes
+
+  - name: Pause 1 second
+    pause:
+      seconds: 1
+
+  - name: Test by doing lookup of api-int
+    command: nslookup -timeout=1 api-int.{{ domain_suffix }} {{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}
+    delegate_to: 127.0.0.1
+    retries: 3
+    delay: 1
+    register: result
+    until: result.rc == 0

--- a/upi/vsphere/stage2/8.configure-svcs/playbooks/scaleup.sh
+++ b/upi/vsphere/stage2/8.configure-svcs/playbooks/scaleup.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 export ANSIBLE_SSH_RETRIES=8
-ansible-playbook -i /tmp/workingdir/ansible-hosts /usr/local/playbooks/configure_svc_dns.yaml 
+ansible-playbook -i /tmp/workingdir/ansible-hosts /usr/local/playbooks/scaleup_dns.yaml

--- a/upi/vsphere/stage2/8.configure-svcs/playbooks/scaleup_dns.yaml
+++ b/upi/vsphere/stage2/8.configure-svcs/playbooks/scaleup_dns.yaml
@@ -1,0 +1,9 @@
+---
+- hosts: svcs, asvcs, csvcs, esvcs
+  any_errors_fatal: true
+  tasks:
+  - name: Check all DNS servers are functional
+    command: nslookup -timeout=1 api-int.{{ domain_suffix }} {{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}
+    delegate_to: 127.0.0.1
+
+- import_playbook: configure_svc_dns.yaml 

--- a/upi/vsphere/stage2/8.configure-svcs/playbooks/scaleup_dns.yaml
+++ b/upi/vsphere/stage2/8.configure-svcs/playbooks/scaleup_dns.yaml
@@ -2,7 +2,7 @@
 - hosts: svcs, asvcs, csvcs, esvcs
   any_errors_fatal: true
   tasks:
-  - name: Check all DNS servers are functional
+  - name: Check all DNS servers are functional before starting DNS reconfiguration
     command: nslookup -timeout=1 api-int.{{ domain_suffix }} {{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}
     delegate_to: 127.0.0.1
 


### PR DESCRIPTION
Previously, the 8.configure-svcs container, used for scaling in vSphere UPI clusters would restart one DNS server and then the other without actually checking they respond to lookups. This adds a lookup step which fails the playbook if the lookup fails after each service restart, preventing both DNS servers going out of action due to an unexpected failure. 

Also, adds a stub playbook for scaleups that checks all DNS servers are functional before starting the reconfig (cannot be included in the main playbook because it would prevent it being used for new deploys...)

Note that it uses `nslookup` command, because although the `community.general.dig` module would seem to be the obvious thing to use, it doesn't fail... ever, so I would have needed to use it to do the lookup, infer the expected IP address result from the inventory file and then compare it with whatever the module returned... this seems ugly and unobvious.