### PR TITLE
Add retention config for ES indexes

### DIFF
--- a/post-deployment/openstack/logging.yml
+++ b/post-deployment/openstack/logging.yml
@@ -190,6 +190,13 @@
               schedule: 0 1 * * *
           logStore:
             type: "elasticsearch"
+            retentionPolicy: 
+              application:
+                maxAge: 7d
+              infra:
+                maxAge: 7d
+              audit:
+                maxAge: 3d
             elasticsearch:
               nodeCount: 1
               nodeSelector:


### PR DESCRIPTION
Will a week fit in 200GB for most clusters? Discuss....

Set audit to 3day; it's not enabled by default in fluentd but if it becomes enabled then it is very noisy. 