### PR TITLE
ExtraGateway Ingress

### DIFF
--- a/post-deployment/openstack/eg-ingress/build/Dockerfile
+++ b/post-deployment/openstack/eg-ingress/build/Dockerfile
@@ -1,0 +1,18 @@
+# FROM ansible-runner:latest
+FROM docker.io/ansible/ansible-runner@sha256:4c6034798b5e724c5a59466f5438e14480c53bc4adac5cc9db5e3997a286a0e4
+
+WORKDIR /usr/local/
+
+ADD ./playbooks /usr/local/playbooks
+COPY ./pip-requirements.txt /usr/local/pip-requirements.txt
+COPY ./ansible-requirements.yml /usr/local/ansible-requirements.yml
+
+# Upgrade pip and install requirements for Kubernetes/Openstack modules
+RUN pip3 install --upgrade pip && \
+    pip3 install -U setuptools && \
+    pip3 install -r /usr/local/pip-requirements.txt --ignore-installed PyYAML
+
+# Install Ansible collections for Kubernetes/Openstack modules
+RUN ansible-galaxy collection install -r /usr/local/ansible-requirements.yml
+
+ENTRYPOINT /usr/local/playbooks/entrypoint.sh

--- a/post-deployment/openstack/eg-ingress/build/ansible-requirements.yml
+++ b/post-deployment/openstack/eg-ingress/build/ansible-requirements.yml
@@ -1,0 +1,6 @@
+---
+collections:
+- name: openstack.cloud
+  version: "1.2.0"
+- name: community.kubernetes
+  version: "1.2.0"

--- a/post-deployment/openstack/eg-ingress/build/pip-requirements.txt
+++ b/post-deployment/openstack/eg-ingress/build/pip-requirements.txt
@@ -1,0 +1,6 @@
+openshift~=0.12.0
+PyYAML~=5.4.1
+jmespath~=0.10.0
+openstacksdk~=0.56.0
+python-octaviaclient~=2.3.0
+python-openstackclient~=5.5.0

--- a/post-deployment/openstack/eg-ingress/build/playbooks/entrypoint.sh
+++ b/post-deployment/openstack/eg-ingress/build/playbooks/entrypoint.sh
@@ -7,4 +7,4 @@ if [ `id -u` -ge 500 ]; then
     rm /tmp/passwd
 fi
 
-ansible-playbook /usr/local/playbooks/update_net2_loadbalancer_members.yaml
+ansible-playbook /usr/local/playbooks/update_eg_loadbalancer_members.yaml

--- a/post-deployment/openstack/eg-ingress/build/playbooks/update_eg_loadbalancer_members.yaml
+++ b/post-deployment/openstack/eg-ingress/build/playbooks/update_eg_loadbalancer_members.yaml
@@ -44,7 +44,7 @@
     ansible.builtin.shell: openstack loadbalancer pool list -c name -f value | grep -eg-
     register: loadbalancerPoolsRaw
 
-  - name: Sanitise loadbalancer pools
+  - name: 'Sanitise loadbalancer pools'
     ansible.builtin.set_fact:
       loadbalancerPools: "{{ loadbalancerPoolsRaw.stdout_lines }}"
 

--- a/post-deployment/openstack/eg-ingress/build/playbooks/update_eg_loadbalancer_members.yaml
+++ b/post-deployment/openstack/eg-ingress/build/playbooks/update_eg_loadbalancer_members.yaml
@@ -22,26 +22,26 @@
       dest: /etc/openstack/clouds.yaml
       content: "{{ openstackCredential | b64decode }}"
 
-  - name: 'Get net2 nodes'
+  - name: 'Get infra nodes'
     community.kubernetes.k8s_info:
       kind: Node
       label_selectors:
-        - node-role.kubernetes.io/net2 =
-    register: net2Nodes
+        - node-role.kubernetes.io/infra =
+    register: infraNodes
 
-  - name: 'Extract net2 node IPs'
+  - name: 'Extract infra node IPs'
     ansible.builtin.set_fact:
-      net2MembersRaw: "{{ net2Nodes | to_json | from_json | json_query(net2MembersRawQuery) }}"
+      infraMembersRaw: "{{ infraNodes | to_json | from_json | json_query(infraMembersRawQuery) }}"
     vars:
-      net2MembersRawQuery: "resources[*].status.addresses[?type=='InternalIP'].address"
+      infraMembersRawQuery: "resources[*].status.addresses[?type=='InternalIP'].address"
 
-  - name: 'Build net2 node IP dict'
+  - name: 'Build infra node IP dict'
     ansible.builtin.set_fact:
-      net2Members: "{{ net2Members | default([]) + [ item ] }}"
-    with_items: "{{ net2MembersRaw }}"
+      infraMembers: "{{ infraMembers | default([]) + [ item ] }}"
+    with_items: "{{ infraMembersRaw }}"
 
   - name: 'Get loadbalancer pools'
-    ansible.builtin.command: openstack loadbalancer pool list -c name -f value
+    ansible.builtin.shell: openstack loadbalancer pool list -c name -f value | grep -eg-
     register: loadbalancerPoolsRaw
 
   - name: Sanitise loadbalancer pools
@@ -59,9 +59,9 @@
   - name: 'Determine members to be added'
     ansible.builtin.set_fact:
       loadbalancerMembersToAdd: "{{ loadbalancerMembersToAdd | default([]) + [ item ] }}"
-    with_items: "{{ net2Members }}"
+    with_items: "{{ infraMembers }}"
     when: 
-      - net2Members is defined
+      - infraMembers is defined
       - item not in loadbalancerMembers
 
   - name: 'Determine members to be deleted'
@@ -69,15 +69,15 @@
       loadbalancerMembersToDelete: "{{ loadbalancerMembersToDelete | default([]) + [ item ] }}"
     with_items: "{{ loadbalancerMembers }}"
     when: 
-      - net2Members is defined
-      - item not in net2Members
+      - infraMembers is defined
+      - item not in infraMembers
 
   - name: 'Add loadbalancer members'
     openstack.cloud.lb_member:
       name: "{{ item[1] }}"
       address: "{{ item[1] }}"
       pool: "{{ item[0] }}"
-      protocol_port: "{{ 443 if '-HTTPS-' in item[0] else 80 }}"
+      protocol_port: "{{ 30443 if '-HTTPS-' in item[0] else 30080 }}"
       state: present
     with_nested:
       - "{{ loadbalancerPools }}"

--- a/post-deployment/openstack/eg-ingress/build/playbooks/update_eg_loadbalancer_members.yaml
+++ b/post-deployment/openstack/eg-ingress/build/playbooks/update_eg_loadbalancer_members.yaml
@@ -41,7 +41,7 @@
     with_items: "{{ infraMembersRaw }}"
 
   - name: 'Get loadbalancer pools'
-    ansible.builtin.shell: openstack loadbalancer pool list -c name -f value | grep -eg-
+    ansible.builtin.shell: openstack loadbalancer pool list -c name -f value | grep -- -eg-
     register: loadbalancerPoolsRaw
 
   - name: 'Sanitise loadbalancer pools'

--- a/post-deployment/openstack/eg-ingress/main.yml
+++ b/post-deployment/openstack/eg-ingress/main.yml
@@ -48,7 +48,10 @@
     args:
       chdir: "./build"
     register: loadbalancerBuildStatus
-    failed_when: "'Push successful' not in loadbalancerBuildStatus.stdout_lines"
+    until:
+      - "'Push successful' in loadbalancerBuildStatus.stdout_lines"
+    retries: 3
+    delay: 60
 
   - name: Delete BuildConfig
     k8s:

--- a/post-deployment/openstack/eg-ingress/main.yml
+++ b/post-deployment/openstack/eg-ingress/main.yml
@@ -4,7 +4,7 @@
 
   vars:
     namespace: "ukc-ingress"
-    net2NetworkName: "{{ net2ExternalNetwork | replace(' ','-') | replace('_','-') | lower }}"
+    extraGatewayNetworkName: "{{ extraGatewayExternalNetwork | replace(' ','-') | replace('_','-') | lower }}"
 
   tasks:
   - name: Create ImageStream
@@ -14,7 +14,7 @@
         apiVersion: image.openshift.io/v1
         kind: ImageStream
         metadata:
-          name: update-net2-loadbalancer-members
+          name: update-eg-loadbalancer-members
           namespace: "{{ namespace }}"
         spec:
           lookupPolicy:
@@ -28,14 +28,14 @@
         kind: BuildConfig
         metadata:
           labels:
-            build: update-net2-loadbalancer-members
-          name: update-net2-loadbalancer-members
+            build: update-eg-loadbalancer-members
+          name: update-eg-loadbalancer-members
           namespace: "{{ namespace }}"
         spec:
           output:
             to:
               kind: ImageStreamTag
-              name: update-net2-loadbalancer-members:latest
+              name: update-eg-loadbalancer-members:latest
           source:
             binary: {}
             type: Binary
@@ -44,7 +44,7 @@
             type: Docker
 
   - name: Run Docker build
-    command: "oc start-build update-net2-loadbalancer-members --from-dir . -F -n {{ namespace }}"
+    command: "oc start-build update-eg-loadbalancer-members --from-dir . -F -n {{ namespace }}"
     args:
       chdir: "./build"
     register: loadbalancerBuildStatus
@@ -57,13 +57,13 @@
         apiVersion: build.openshift.io/v1
         kind: BuildConfig
         metadata:
-          name: update-net2-loadbalancer-members
+          name: update-eg-loadbalancer-members
           namespace: "{{ namespace }}"
 
-  - name: Create update-net2-loadbalancer-members CronJob
+  - name: Create update-eg-loadbalancer-members CronJob
     k8s:
       state: present
-      definition: "{{ lookup('template', 'templates/cronjob-update-net2-loadbalancer-members.j2') }}"
+      definition: "{{ lookup('template', 'templates/cronjob-update-eg-loadbalancer-members.j2') }}"
 
   - name: Create IngressController
     k8s:
@@ -73,17 +73,41 @@
         kind: IngressController
         metadata:
           namespace: openshift-ingress-operator
-          name: "{{ net2NetworkName }}"
+          name: extragateway
         spec:
-          domain: "{{ net2NetworkName }}.{{ domainSuffix }}"
+          domain: "{{ extraGatewayNetworkName }}.{{ domainSuffix }}"
           nodePlacement:
             nodeSelector:
               matchLabels:
-                network: "{{ net2NetworkName }}"
+                node-role.kubernetes.io/infra: ""
+          endpointPublishingStrategy:
+            type: NodePortService
           replicas: 2
           routeSelector:
             matchExpressions:
             - key: network
               operator: In
               values:
-              - "{{ net2NetworkName }}"
+              - "{{ extraGatewayNetworkName }}"
+
+  - name: Statically set NodePortService port numbers
+    k8s:
+      state: present
+      definition:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: router-nodeport-extragateway
+          namespace: openshift-ingress
+        spec:
+          ports:
+          - name: http
+            nodePort: 30080
+            port: 80
+            protocol: TCP
+            targetPort: http
+          - name: https
+            nodePort: 30443
+            port: 443
+            protocol: TCP
+            targetPort: https

--- a/post-deployment/openstack/eg-ingress/main.yml
+++ b/post-deployment/openstack/eg-ingress/main.yml
@@ -47,10 +47,10 @@
     command: "oc start-build update-eg-loadbalancer-members --from-dir . -F -n {{ namespace }}"
     args:
       chdir: "./build"
-    register: loadbalancerBuildStatus
+    register: egLoadbalancerBuildStatus
     until:
-      - "'Push successful' in loadbalancerBuildStatus.stdout_lines"
-    retries: 3
+      - "'Push successful' in egLoadbalancerBuildStatus.stdout_lines"
+    retries: 5
     delay: 60
 
   - name: Delete BuildConfig

--- a/post-deployment/openstack/eg-ingress/main.yml
+++ b/post-deployment/openstack/eg-ingress/main.yml
@@ -4,7 +4,7 @@
 
   vars:
     namespace: "ukc-ingress"
-    extraGatewayNetworkName: "{{ extraGatewayExternalNetwork | replace(' ','-') | replace('_','-') | lower }}"
+    extraGatewayNetworkName: "{{ egExternalNetwork | replace(' ','-') | replace('_','-') | lower }}"
 
   tasks:
   - name: Create ImageStream
@@ -114,3 +114,18 @@
             port: 443
             protocol: TCP
             targetPort: https
+
+  - name: Ensure default IngressController does not pickup EG routes
+    k8s:
+      state: present
+      definition:
+        apiVersion: operator.openshift.io/v1
+        kind: IngressController
+        metadata:
+          name: default
+          namespace: openshift-ingress-operator
+        spec:
+          routeSelector:
+            matchExpressions:
+            - key: network
+              operator: DoesNotExist

--- a/post-deployment/openstack/eg-ingress/templates/cronjob-update-eg-loadbalancer-members.j2
+++ b/post-deployment/openstack/eg-ingress/templates/cronjob-update-eg-loadbalancer-members.j2
@@ -1,7 +1,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: "update-loadbalancer-members"
+  name: "update-eg-loadbalancer-members"
   namespace: "{{ namespace }}"
 spec:
   schedule: "*/5 * * * *"
@@ -14,8 +14,8 @@ spec:
       template:
         spec:
           containers:
-          - name: update-loadbalancer-members
-            image: update-loadbalancer-members
+          - name: update-eg-loadbalancer-members
+            image: update-eg-loadbalancer-members
             env:
             - name: K8S_AUTH_API_KEY
               valueFrom:

--- a/post-deployment/openstack/ingress/build/playbooks/templates/eg_ingress_controller.j2
+++ b/post-deployment/openstack/ingress/build/playbooks/templates/eg_ingress_controller.j2
@@ -1,0 +1,7 @@
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+    namespace: openshift-ingress-operator
+    name: extragateway
+spec:
+    replicas: {{ infraNodes.resources | length }}

--- a/post-deployment/openstack/ingress/build/playbooks/update_ingress_controllers.yaml
+++ b/post-deployment/openstack/ingress/build/playbooks/update_ingress_controllers.yaml
@@ -34,3 +34,8 @@
       state: present
       definition: "{{ lookup('template', 'templates/net2_ingress_controller.j2') }}"
     with_items: "{{ net2Networks | unique }}"
+
+  - name: Update extragateway ingresscontroller replicas
+    k8s:
+      state: present
+      definition: "{{ lookup('template', 'templates/eg_ingress_controller.j2') }}"

--- a/post-deployment/openstack/ingress/build/playbooks/update_ingress_controllers.yaml
+++ b/post-deployment/openstack/ingress/build/playbooks/update_ingress_controllers.yaml
@@ -18,24 +18,32 @@
         - node-role.kubernetes.io/net2 =
     register: net2Nodes
 
+  - name: 'Get ingresscontrollers'
+    community.kubernetes.k8s_info:
+      kind: IngressController
+      namespace: openshift-ingress-operator
+      name: extragateway
+    register: egIngressController
+
   - name: 'Extract net2 network name'
     ansible.builtin.set_fact:
       net2Networks: "{{ net2Nodes | to_json | from_json | json_query(net2NetworksQuery) }}"
     vars:
       net2NetworksQuery: "resources[*].metadata.labels.network"
 
-  - name: Update default ingresscontroller replicas
-    k8s:
+  - name: 'Update default ingresscontroller replicas'
+    community.kubernetes.k8s:
       state: present
       definition: "{{ lookup('template', 'templates/default_ingress_controller.j2') }}"
 
-  - name: Update net2 ingresscontroller replicas
-    k8s:
+  - name: 'Update net2 ingresscontroller replicas'
+    community.kubernetes.k8s:
       state: present
       definition: "{{ lookup('template', 'templates/net2_ingress_controller.j2') }}"
     with_items: "{{ net2Networks | unique }}"
 
-  - name: Update extragateway ingresscontroller replicas
-    k8s:
+  - name: 'Update extragateway ingresscontroller replicas'
+    community.kubernetes.k8s:
       state: present
       definition: "{{ lookup('template', 'templates/eg_ingress_controller.j2') }}"
+    when: egIngressController.resources | length > 0

--- a/post-deployment/openstack/ingress/main.yml
+++ b/post-deployment/openstack/ingress/main.yml
@@ -70,7 +70,10 @@
     args:
       chdir: "./build"
     register: ingressBuildStatus
-    failed_when: "'Push successful' not in ingressBuildStatus.stdout_lines"
+    until:
+      - "'Push successful' in ingressBuildStatus.stdout_lines"
+    retries: 3
+    delay: 60
 
   - name: Delete BuildConfig
     k8s:

--- a/post-deployment/openstack/ingress/main.yml
+++ b/post-deployment/openstack/ingress/main.yml
@@ -72,7 +72,7 @@
     register: ingressBuildStatus
     until:
       - "'Push successful' in ingressBuildStatus.stdout_lines"
-    retries: 3
+    retries: 5
     delay: 60
 
   - name: Delete BuildConfig

--- a/post-deployment/openstack/net2-ingress/build/playbooks/update_net2_loadbalancer_members.yaml
+++ b/post-deployment/openstack/net2-ingress/build/playbooks/update_net2_loadbalancer_members.yaml
@@ -41,7 +41,7 @@
     with_items: "{{ net2MembersRaw }}"
 
   - name: 'Get loadbalancer pools'
-    ansible.builtin.shell: openstack loadbalancer pool list -c name -f value | grep -net2-
+    ansible.builtin.shell: openstack loadbalancer pool list -c name -f value | grep -- -net2-
     register: loadbalancerPoolsRaw
 
   - name: 'Sanitise loadbalancer pools'

--- a/post-deployment/openstack/net2-ingress/build/playbooks/update_net2_loadbalancer_members.yaml
+++ b/post-deployment/openstack/net2-ingress/build/playbooks/update_net2_loadbalancer_members.yaml
@@ -1,0 +1,95 @@
+---
+- hosts: localhost
+  connection: local
+  gather_facts: no
+
+  tasks:
+  - name: 'Retrieve OpenStack secret'
+    community.kubernetes.k8s_info:
+      kind: Secret
+      name: openstack-credentials
+      namespace: kube-system
+    register: openstackCredentialRaw
+
+  - name: 'Extract OpenStack credential'
+    ansible.builtin.set_fact:
+      openstackCredential: "{{ openstackCredentialRaw | to_json | from_json | json_query(openstackCredentialQuery) }}"
+    vars:
+      openstackCredentialQuery: 'resources[0].data."clouds.yaml"'
+
+  - name: 'Write OpenStack credential to file'
+    ansible.builtin.copy:
+      dest: /etc/openstack/clouds.yaml
+      content: "{{ openstackCredential | b64decode }}"
+
+  - name: 'Get net2 nodes'
+    community.kubernetes.k8s_info:
+      kind: Node
+      label_selectors:
+        - node-role.kubernetes.io/net2 =
+    register: net2Nodes
+
+  - name: 'Extract net2 node IPs'
+    ansible.builtin.set_fact:
+      net2MembersRaw: "{{ net2Nodes | to_json | from_json | json_query(net2MembersRawQuery) }}"
+    vars:
+      net2MembersRawQuery: "resources[*].status.addresses[?type=='InternalIP'].address"
+
+  - name: 'Build net2 node IP dict'
+    ansible.builtin.set_fact:
+      net2Members: "{{ net2Members | default([]) + [ item ] }}"
+    with_items: "{{ net2MembersRaw }}"
+
+  - name: 'Get loadbalancer pools'
+    ansible.builtin.shell: openstack loadbalancer pool list -c name -f value | grep -net2-
+    register: loadbalancerPoolsRaw
+
+  - name: Sanitise loadbalancer pools
+    ansible.builtin.set_fact:
+      loadbalancerPools: "{{ loadbalancerPoolsRaw.stdout_lines }}"
+
+  - name: 'Get loadbalancer pool members'
+    ansible.builtin.command: openstack loadbalancer member list "{{ loadbalancerPools | first }}" -c address -f value
+    register: loadbalancerMembersRaw
+
+  - name: 'Sanitise loadbalancer pool members'
+    ansible.builtin.set_fact:
+      loadbalancerMembers: "{{ loadbalancerMembersRaw.stdout_lines }}"
+
+  - name: 'Determine members to be added'
+    ansible.builtin.set_fact:
+      loadbalancerMembersToAdd: "{{ loadbalancerMembersToAdd | default([]) + [ item ] }}"
+    with_items: "{{ net2Members }}"
+    when: 
+      - net2Members is defined
+      - item not in loadbalancerMembers
+
+  - name: 'Determine members to be deleted'
+    ansible.builtin.set_fact:
+      loadbalancerMembersToDelete: "{{ loadbalancerMembersToDelete | default([]) + [ item ] }}"
+    with_items: "{{ loadbalancerMembers }}"
+    when: 
+      - net2Members is defined
+      - item not in net2Members
+
+  - name: 'Add loadbalancer members'
+    openstack.cloud.lb_member:
+      name: "{{ item[1] }}"
+      address: "{{ item[1] }}"
+      pool: "{{ item[0] }}"
+      protocol_port: "{{ 443 if '-HTTPS-' in item[0] else 80 }}"
+      state: present
+    with_nested:
+      - "{{ loadbalancerPools }}"
+      - "{{ loadbalancerMembersToAdd }}"
+    when: loadbalancerMembersToAdd is defined
+
+  - name: 'Delete loadbalancer members'
+    openstack.cloud.lb_member:
+      name: "{{ item[1] }}"
+      pool: "{{ item[0] }}"
+      state: absent
+    with_nested:
+      - "{{ loadbalancerPools }}"
+      - "{{ loadbalancerMembersToDelete }}"
+    when: loadbalancerMembersToDelete is defined

--- a/post-deployment/openstack/net2-ingress/build/playbooks/update_net2_loadbalancer_members.yaml
+++ b/post-deployment/openstack/net2-ingress/build/playbooks/update_net2_loadbalancer_members.yaml
@@ -44,7 +44,7 @@
     ansible.builtin.shell: openstack loadbalancer pool list -c name -f value | grep -net2-
     register: loadbalancerPoolsRaw
 
-  - name: Sanitise loadbalancer pools
+  - name: 'Sanitise loadbalancer pools'
     ansible.builtin.set_fact:
       loadbalancerPools: "{{ loadbalancerPoolsRaw.stdout_lines }}"
 

--- a/post-deployment/openstack/net2-ingress/main.yml
+++ b/post-deployment/openstack/net2-ingress/main.yml
@@ -48,7 +48,10 @@
     args:
       chdir: "./build"
     register: loadbalancerBuildStatus
-    failed_when: "'Push successful' not in loadbalancerBuildStatus.stdout_lines"
+    until:
+      - "'Push successful' in loadbalancerBuildStatus.stdout_lines"
+    retries: 3
+    delay: 60
 
   - name: Delete BuildConfig
     k8s:

--- a/post-deployment/openstack/net2-ingress/main.yml
+++ b/post-deployment/openstack/net2-ingress/main.yml
@@ -90,3 +90,18 @@
               operator: In
               values:
               - "{{ net2NetworkName }}"
+
+  - name: Ensure default IngressController does not pickup net2 routes
+    k8s:
+      state: present
+      definition:
+        apiVersion: operator.openshift.io/v1
+        kind: IngressController
+        metadata:
+          name: default
+          namespace: openshift-ingress-operator
+        spec:
+          routeSelector:
+            matchExpressions:
+            - key: network
+              operator: DoesNotExist

--- a/post-deployment/openstack/net2-ingress/main.yml
+++ b/post-deployment/openstack/net2-ingress/main.yml
@@ -47,10 +47,10 @@
     command: "oc start-build update-net2-loadbalancer-members --from-dir . -F -n {{ namespace }}"
     args:
       chdir: "./build"
-    register: loadbalancerBuildStatus
+    register: net2LoadbalancerBuildStatus
     until:
-      - "'Push successful' in loadbalancerBuildStatus.stdout_lines"
-    retries: 3
+      - "'Push successful' in net2LoadbalancerBuildStatus.stdout_lines"
+    retries: 5
     delay: 60
 
   - name: Delete BuildConfig

--- a/post-deployment/openstack/net2-ingress/templates/cronjob-update-net2-loadbalancer-members.j2
+++ b/post-deployment/openstack/net2-ingress/templates/cronjob-update-net2-loadbalancer-members.j2
@@ -14,8 +14,8 @@ spec:
       template:
         spec:
           containers:
-          - name: update-loadbalancer-members
-            image: update-loadbalancer-members
+          - name: update-net2-loadbalancer-members
+            image: update-net2-loadbalancer-members
             env:
             - name: K8S_AUTH_API_KEY
               valueFrom:

--- a/post-deployment/openstack/net2-ingress/templates/cronjob-update-net2-loadbalancer-members.j2
+++ b/post-deployment/openstack/net2-ingress/templates/cronjob-update-net2-loadbalancer-members.j2
@@ -1,0 +1,35 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: "update-net2-loadbalancer-members"
+  namespace: "{{ namespace }}"
+spec:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: "Replace"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        spec:
+          containers:
+          - name: update-loadbalancer-members
+            image: update-loadbalancer-members
+            env:
+            - name: K8S_AUTH_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "ukc-ingress-sa"
+                  key: token
+            - name: K8S_AUTH_HOST
+              value: "https://api.{{ domainSuffix}}:6443"
+            - name: OS_CLOUD
+              value: openstack
+            volumeMounts:
+            - mountPath: "/etc/openstack"
+              name: clouds
+          volumes:
+            - name: clouds
+              emptyDir: {}
+          restartPolicy: Never

--- a/post-deployment/openstack/post-deployment.yml
+++ b/post-deployment/openstack/post-deployment.yml
@@ -29,5 +29,7 @@
 - import_playbook: ingress/main.yml
 - import_playbook: net2-ingress/main.yml
   when: net2 | default(false) | bool
+- import_playbook: eg-ingress/main.yml
+  when: extraGateway | default(false) | bool
 - import_playbook: ingress/letsencrypt.yml
   when: useLetsEncryptCert | default(true) | bool

--- a/post-deployment/openstack/post-deployment.yml
+++ b/post-deployment/openstack/post-deployment.yml
@@ -27,6 +27,7 @@
 - import_playbook: acme-sa.yml
   when: useLetsEncryptCert | default(true) | bool
 - import_playbook: ingress/main.yml
+  when: (extraGateway | default(false) | bool) or (net2 | default(false) | bool)
 - import_playbook: net2-ingress/main.yml
   when: net2 | default(false) | bool
 - import_playbook: eg-ingress/main.yml

--- a/post-deployment/openstack/vars.yml
+++ b/post-deployment/openstack/vars.yml
@@ -23,7 +23,7 @@ opsviewName: <name>
 #net2ExternalNetwork:  <net2 external network>
 ## Set to true when deploying extraGateway, defaults to false
 #extraGateway: true
-#extraGatewayExternalNetwork:  <extraGateway external network>
+#egExternalNetwork:  <extraGateway external network>
 ## Set to false to prevent isolation NetworkPolicy's being added to 
 ## default project template, defaults to true:
 #isolateProjectsNetworkPolicy: false

--- a/post-deployment/openstack/vars.yml
+++ b/post-deployment/openstack/vars.yml
@@ -21,6 +21,9 @@ opsviewName: <name>
 ## Set to true when deploying net2, defaults to false
 #net2: true
 #net2ExternalNetwork:  <net2 external network>
+## Set to true when deploying extraGateway, defaults to false
+#extraGateway: true
+#extraGatewayExternalNetwork:  <extraGateway external network>
 ## Set to false to prevent isolation NetworkPolicy's being added to 
 ## default project template, defaults to true:
 #isolateProjectsNetworkPolicy: false


### PR DESCRIPTION
Similar to net2 ingress, builds an image that manages Octavia loadbalancer members; these members being additional routers (backed by an IngressController) running on infra nodes listening via a NodePort. A CronJob is created and runs every 5 minutes to ensure that the members match the current infra nodes to ensure ingress traffic is unaffected due to node scaling. In addition another CronJob runs every 5 minutes to ensure there are as many routers as there are infra nodes to provide redundancy.

Also includes minor tweaks to other post-deployment builds to give them more chance of succeeding.