### PR TITLE
Net2 ntp

### DIFF
--- a/post-deployment/openstack/net2-ntp.yml
+++ b/post-deployment/openstack/net2-ntp.yml
@@ -1,0 +1,56 @@
+---
+- hosts: localhost
+  connection: local
+
+  tasks:
+  - name: Template /etc/chrony.conf
+    set_fact: 
+      chronyconf: | 
+        {% for ntpserver in net2NTPServers %}server {{ ntpserver }} iburst
+        {% endfor %}
+        driftfile /var/lib/chrony/drift
+        makestep 1.0 3
+        rtcsync
+        logdir /var/log/chrony  
+    when: net2NTPServers is defined
+
+  - name: Create Net2 NTP MachineConfig
+    k8s:
+      state: present
+      definition:
+        apiVersion: machineconfiguration.openshift.io/v1
+        kind: MachineConfig
+        metadata:
+          labels:
+            machineconfiguration.openshift.io/role: net2
+          name: 03-net2-ntp
+        spec:
+          config:
+            ignition:
+              version: 3.2.0
+            storage:
+              files:
+              - path: /etc/chrony.conf
+                mode: 0644
+                overwrite: true
+                contents:
+                  source: "data:,{{ chronyconf | urlencode }}"  
+    when: net2NTPServers is defined
+
+  - name: Create Net2 MachineConfigPool
+    k8s:
+      state: present
+      definition:
+        apiVersion: machineconfiguration.openshift.io/v1
+        kind: MachineConfigPool
+        metadata:
+          name: net2
+        spec:
+          machineConfigSelector:
+            matchExpressions:
+              - { key: machineconfiguration.openshift.io/role, operator: In, values: [ worker, net2 ] }
+          nodeSelector:
+            matchLabels:
+              node-role.kubernetes.io/net2: ""
+    when: net2NTPServers is defined
+

--- a/post-deployment/openstack/post-deployment.yml
+++ b/post-deployment/openstack/post-deployment.yml
@@ -15,6 +15,8 @@
 - import_playbook: object-storage.yml
 - import_playbook: infra.yml
 - import_playbook: storage.yml
+- import_playbook: net2-ntp.yml
+  when: net2 | default(false) | bool
 - import_playbook: logging.yml
   when: logging | bool  
 - import_playbook: dns-forwarding.yml

--- a/post-deployment/openstack/vars.yml
+++ b/post-deployment/openstack/vars.yml
@@ -10,6 +10,7 @@ bucketName: <object store bucket>
 regionEndpoint: <object storage region endpoint>
 accessKey: <access key>
 secretKey: <secret key>
+
 # Optional add ons
 logging: <boolean>
 # Opsview host name format cnaxxxxx-<customer>
@@ -18,15 +19,20 @@ opsviewName: <name>
 #useSingleSignOn: false
 ## Set to false when using self-signed certificates, defaults to true:
 #useLetsEncryptCert: false
+
 ## Set to true when deploying net2, defaults to false
 #net2: true
 #net2ExternalNetwork:  <net2 external network>
+#net2NTPServers: ["1.2.3.4","6.7.8.9"]    # List of NTP servers accessible on the net2 network
+
 ## Set to true when deploying extraGateway, defaults to false
 #extraGateway: true
 #egExternalNetwork:  <extraGateway external network>
+
 ## Set to false to prevent isolation NetworkPolicy's being added to 
 ## default project template, defaults to true:
 #isolateProjectsNetworkPolicy: false
+
 # DNS Forwarding - omit or set to {} to disable
 dnsforwardingzones: 
   - name: foo-dns


### PR DESCRIPTION
Adds a playbook to configure NTP servers specifically for net2 nodes (other nodes remain using the default Red Hat pool on the internet for now)