### PR TITLE
Nodeport loadbalancing

### DIFF
--- a/post-deployment/openstack/nodeport-loadbalancing-ingress/build/Dockerfile
+++ b/post-deployment/openstack/nodeport-loadbalancing-ingress/build/Dockerfile
@@ -1,0 +1,18 @@
+# FROM ansible-runner:latest
+FROM quay.io/ansible/ansible-runner:stable-2.10-latest
+
+WORKDIR /usr/local/
+
+ADD ./playbooks /usr/local/playbooks
+COPY ./pip-requirements.txt /usr/local/pip-requirements.txt
+COPY ./ansible-requirements.yml /usr/local/ansible-requirements.yml
+
+# Upgrade pip and install requirements for Kubernetes/Openstack modules
+RUN pip3 install --upgrade pip && \
+    pip3 install -U setuptools && \
+    pip3 install -r /usr/local/pip-requirements.txt --ignore-installed PyYAML
+
+# Install Ansible collections for Kubernetes/Openstack modules
+RUN ansible-galaxy collection install -r /usr/local/ansible-requirements.yml
+
+ENTRYPOINT /usr/local/playbooks/entrypoint.sh

--- a/post-deployment/openstack/nodeport-loadbalancing-ingress/build/Dockerfile
+++ b/post-deployment/openstack/nodeport-loadbalancing-ingress/build/Dockerfile
@@ -1,5 +1,5 @@
 # FROM ansible-runner:latest
-FROM quay.io/ansible/ansible-runner:stable-2.10-latest
+FROM quay.io/ansible/ansible-runner:stable-2.11-latest
 
 WORKDIR /usr/local/
 

--- a/post-deployment/openstack/nodeport-loadbalancing-ingress/build/ansible-requirements.yml
+++ b/post-deployment/openstack/nodeport-loadbalancing-ingress/build/ansible-requirements.yml
@@ -1,0 +1,8 @@
+---
+collections:
+- name: openstack.cloud
+  version: "1.5.1"
+- name: community.kubernetes
+  version: "1.2.0"
+- name: community.general
+  version: "3.7.0"

--- a/post-deployment/openstack/nodeport-loadbalancing-ingress/build/ansible-requirements.yml
+++ b/post-deployment/openstack/nodeport-loadbalancing-ingress/build/ansible-requirements.yml
@@ -3,6 +3,6 @@ collections:
 - name: openstack.cloud
   version: "1.5.1"
 - name: community.kubernetes
-  version: "1.2.0"
+  version: "1.2.1"
 - name: community.general
-  version: "3.7.0"
+  version: "3.8.1"

--- a/post-deployment/openstack/nodeport-loadbalancing-ingress/build/pip-requirements.txt
+++ b/post-deployment/openstack/nodeport-loadbalancing-ingress/build/pip-requirements.txt
@@ -1,0 +1,6 @@
+openshift~=0.12.0
+PyYAML~=5.4.1
+jmespath~=0.10.0
+openstacksdk~=0.56.0
+python-octaviaclient~=2.3.0
+python-openstackclient~=5.5.0

--- a/post-deployment/openstack/nodeport-loadbalancing-ingress/build/pip-requirements.txt
+++ b/post-deployment/openstack/nodeport-loadbalancing-ingress/build/pip-requirements.txt
@@ -1,6 +1,6 @@
-openshift~=0.12.0
-PyYAML~=5.4.1
+openshift~=0.12.1
+PyYAML~=6.0
 jmespath~=0.10.0
-openstacksdk~=0.56.0
-python-octaviaclient~=2.3.0
-python-openstackclient~=5.5.0
+openstacksdk~=0.59.0
+python-octaviaclient~=2.4.0
+python-openstackclient~=5.6.0

--- a/post-deployment/openstack/nodeport-loadbalancing-ingress/build/playbooks/entrypoint.sh
+++ b/post-deployment/openstack/nodeport-loadbalancing-ingress/build/playbooks/entrypoint.sh
@@ -1,0 +1,10 @@
+export K8S_AUTH_VERIFY_SSL=no
+
+# Add uid to /etc/passwd to allow Ansible to run
+if [ `id -u` -ge 500 ]; then
+    echo "runner:x:`id -u`:`id -g`:,,,:/runner:/bin/bash" > /tmp/passwd
+    cat /tmp/passwd >> /etc/passwd
+    rm /tmp/passwd
+fi
+
+ansible-playbook /usr/local/playbooks/update-nodeport-loadbalancer-members.yaml

--- a/post-deployment/openstack/nodeport-loadbalancing-ingress/build/playbooks/update-nodeport-loadbalancer-members.yaml
+++ b/post-deployment/openstack/nodeport-loadbalancing-ingress/build/playbooks/update-nodeport-loadbalancer-members.yaml
@@ -1,0 +1,179 @@
+---
+- hosts: localhost
+  connection: local
+  gather_facts: no
+
+  tasks:
+  - name: 'Retrieve OpenStack secret'
+    community.kubernetes.k8s_info:
+      kind: Secret
+      name: openstack-credentials
+      namespace: kube-system
+    register: openstackCredentialRaw
+
+  - name: 'Extract OpenStack credential'
+    ansible.builtin.set_fact:
+      openstackCredential: "{{ openstackCredentialRaw | to_json | from_json | json_query(openstackCredentialQuery) }}"
+    vars:
+      openstackCredentialQuery: 'resources[0].data."clouds.yaml"'
+
+  - name: 'Write OpenStack credential to file'
+    ansible.builtin.copy:
+      dest: /etc/openstack/clouds.yaml
+      content: "{{ openstackCredential | b64decode }}"
+
+  - name: 'Get a list of Services'
+    community.kubernetes.k8s_info:
+      kind: Service
+    register: service_list
+
+  - name: 'Filter out only NodePort services'
+    ansible.builtin.set_fact:
+      node_port_services: "{{ service_list | to_json | from_json | json_query(nodeportquery) }}"
+    vars:
+      nodeportquery: "resources[?spec.type=='NodePort'].spec.ports[].{TargetPort: targetPort, NodePort: nodePort}"
+
+  - name: 'Filter out all NodePort ports'
+    ansible.builtin.set_fact:
+      ports: "{{ node_port_services | to_json | from_json | json_query(portsquery) | string() }}"
+    vars:
+      portsquery: "[*].NodePort"
+
+  - name: Get NodePort loadbalancer
+    ansible.builtin.shell: openstack loadbalancer list -c name -f value | grep -- -nodeport-
+    register: nodePortLoadbalancer
+
+  - name: Get OpenShift worker nodes
+    community.kubernetes.k8s_info:
+      kind: Node
+      label_selectors: 
+        - node-role.kubernetes.io/app = 
+    register: workerNodes
+
+  - name: Get node names
+    ansible.builtin.set_fact:
+      workerNodeNames: "{{ workerNodes | to_json | from_json | json_query(workerNodeQuery) }}"
+    vars:
+      workerNodeQuery: "resources[*].status.addresses[?type=='InternalIP'].address"
+
+  - name: Flatten node list
+    ansible.builtin.set_fact:
+      workerNodeNames: "{{ workerNodeNames | flatten }}"
+
+  - name: Create listeners on the loadbalancer
+    openstack.cloud.lb_listener:
+      state: present
+      name: "{{ item.NodePort }}"
+      protocol: TCP
+      protocol_port: "{{ item.NodePort }}"
+      loadbalancer: "{{ nodePortLoadbalancer.stdout }}"
+    with_items: "{{ node_port_services }}"
+    when: node_port_services is defined
+
+  - name: Create pools on the loadbalancer
+    openstack.cloud.lb_pool:
+      state: present
+      name: "{{ item.NodePort }}"
+      listener: "{{ item.NodePort }}"
+      lb_algorithm: ROUND_ROBIN
+      protocol: TCP
+    with_items: "{{ node_port_services }}"
+    when: node_port_services is defined
+
+  - name: Add members to each pool on loadbalancer
+    openstack.cloud.lb_member:
+      state: present
+      name: "{{ item[0] }}"
+      address: "{{ item[0] }}"
+      pool: "{{ item[1].NodePort }}"
+      protocol_port: "{{ item[1].NodePort }}"
+    with_nested:
+      - "{{ workerNodeNames }}"
+      - "{{ node_port_services }}"
+    when: node_port_services is defined
+
+  - name: Add health monitors to each members in each pool on loadbalancer
+    openstack.cloud.lb_health_monitor:
+      wait: true
+      type: TCP
+      name: "{{ item.NodePort }}"
+      pool: "{{ item.NodePort }}"
+      max_retries: 3
+      resp_timeout: 5
+      delay: 10
+    with_items: "{{ node_port_services }}"
+    when: node_port_services is defined
+
+  - name: Get NodePort loadbalancer listeners
+    ansible.builtin.shell: openstack loadbalancer listener list -c name -f value
+    register: nodePortLoadbalancerListener
+
+  - name: Get NodePort loadbalancer pools
+    ansible.builtin.shell: openstack loadbalancer pool list -c name -f value
+    register: nodePortLoadbalancerPool
+
+  - name: Get NodePort loadbalancer members per pool
+    ansible.builtin.shell: openstack loadbalancer member list "{{ item }}" -c name -f value
+    with_items: "{{ nodePortLoadbalancerPool.stdout_lines }}"
+    register: nodePortLoadbalancerMember
+
+  - name: Set NodePort list
+    ansible.builtin.set_fact:
+      node_port_services_list: "{{ node_port_services_list | default([]) + [ item.NodePort ] }}"
+    with_items: "{{ node_port_services }}"
+
+  - name: Determine what listeners to delete
+    ansible.builtin.set_fact:
+      loadbalancerListenersToDelete: "{{ loadbalancerListenersToDelete | default([]) + [ item ] }}"
+    with_items: "{{ nodePortLoadbalancerListener.stdout_lines }}"
+    when:
+      - node_port_services is defined
+      - item not in ports
+
+  - name: Determine what pools to delete
+    ansible.builtin.set_fact:
+      loadbalancerPoolsToDelete: "{{ loadbalancerPoolsToDelete | default([]) + [ item ] }}"
+    with_items: "{{ nodePortLoadbalancerPool.stdout_lines }}"
+    when:
+      - node_port_services is defined
+      - item not in ports
+
+  - name: Remove listensers from openstack
+    openstack.cloud.lb_listener:
+      state: absent
+      name: "{{ item }}"
+      loadbalancer: "{{ nodePortLoadbalancer.stdout }}"
+    with_items: "{{ loadbalancerListenersToDelete }}"
+    when: loadbalancerListenersToDelete is defined
+
+  - name: Remove pools openstack
+    openstack.cloud.lb_pool:
+      state: absent
+      name: "{{ item }}"
+      loadbalancer: "{{ nodePortLoadbalancer.stdout }}"
+    with_items: "{{ loadbalancerPoolsToDelete }}"
+    when: loadbalancerPoolsToDelete is defined
+
+  - name: Sanitise members list
+    ansible.builtin.set_fact:
+      loadbalancerMembersList: "{{ nodePortLoadbalancerMember | to_json | from_json | json_query(membersQuery) }}"
+    vars:
+      membersQuery: 'results[0].stdout_lines'
+
+  - name: Determine what members to remove for each pool
+    ansible.builtin.set_fact:
+      loadbalancerMembersToRemove: "{{ loadbalancerMembersToRemove | default([]) + [ item ] }}"
+    with_items: "{{ loadbalancerMembersList }}"
+    when:
+      - nodePortLoadbalancerPool is defined
+      - item not in workerNodeNames
+    
+  - name: Remove member from each pool on loadbalancer
+    openstack.cloud.lb_member:
+      state: absent
+      name: "{{ item[0] }}"
+      pool: "{{ item[1] }}"
+    with_nested:
+      - "{{ loadbalancerMembersToRemove }}"
+      - "{{ node_port_services_list }}"
+    when: loadbalancerMembersToRemove is defined

--- a/post-deployment/openstack/nodeport-loadbalancing-ingress/build/playbooks/update-nodeport-loadbalancer-members.yaml
+++ b/post-deployment/openstack/nodeport-loadbalancing-ingress/build/playbooks/update-nodeport-loadbalancer-members.yaml
@@ -22,22 +22,22 @@
       dest: /etc/openstack/clouds.yaml
       content: "{{ openstackCredential | b64decode }}"
 
-  - name: 'Get a list of Services'
+  - name: Get configmap
     community.kubernetes.k8s_info:
-      kind: Service
-    register: service_list
+      kind: ConfigMap
+      namespace: ukc-ingress
+      name: nodeport-loadbalance
+    register: configmap
 
-  - name: 'Filter out only NodePort services'
+  - name: Grab data from configmap
     ansible.builtin.set_fact:
-      node_port_services: "{{ service_list | to_json | from_json | json_query(nodeportquery) }}"
+      data: "{{ configmap | to_json | from_json | json_query(dataquery) | from_yaml }}"
     vars:
-      nodeportquery: "resources[?spec.type=='NodePort'].spec.ports[].{TargetPort: targetPort, NodePort: nodePort}"
+      dataquery: "resources[0].data.openstack"
 
-  - name: 'Filter out all NodePort ports'
-    ansible.builtin.set_fact:
-      ports: "{{ node_port_services | to_json | from_json | json_query(portsquery) | string() }}"
-    vars:
-      portsquery: "[*].NodePort"
+  - name: print
+    ansible.builtin.debug:
+      var: data
 
   - name: Get NodePort loadbalancer
     ansible.builtin.shell: openstack loadbalancer list -c name -f value | grep -- -nodeport-
@@ -52,91 +52,99 @@
 
   - name: Get node names
     ansible.builtin.set_fact:
-      workerNodeNames: "{{ workerNodes | to_json | from_json | json_query(workerNodeQuery) }}"
+      workerNodeNames: "{{ workerNodes | to_json | from_json | json_query(workerNodeQuery) | flatten }}"
     vars:
       workerNodeQuery: "resources[*].status.addresses[?type=='InternalIP'].address"
-
-  - name: Flatten node list
-    ansible.builtin.set_fact:
-      workerNodeNames: "{{ workerNodeNames | flatten }}"
 
   - name: Create listeners on the loadbalancer
     openstack.cloud.lb_listener:
       state: present
-      name: "{{ item.NodePort }}"
+      name: "{{ item.nodeport }}"
       protocol: TCP
-      protocol_port: "{{ item.NodePort }}"
+      protocol_port: "{{ item.listener }}"
       loadbalancer: "{{ nodePortLoadbalancer.stdout }}"
-    with_items: "{{ node_port_services }}"
-    when: node_port_services is defined
+    loop: "{{ data }}"
+    when: item.nodeport is not none
 
+  - name: Apply allowed CIDR to each listener
+    ansible.builtin.shell:
+      openstack loadbalancer listener set '{{ item.0.nodeport }}' --allowed-cidr "{{ item.1 }}"
+    with_subelements:
+      - "{{ data }}"
+      - allowed_ips
+      - skip_missing: True
+    register: output
+    retries: 3
+    delay: 5
+    until: output.rc == 0
+      
   - name: Create pools on the loadbalancer
     openstack.cloud.lb_pool:
       state: present
-      name: "{{ item.NodePort }}"
-      listener: "{{ item.NodePort }}"
+      name: "{{ item.nodeport }}"
+      listener: "{{ item.nodeport }}"
       lb_algorithm: ROUND_ROBIN
       protocol: TCP
-    with_items: "{{ node_port_services }}"
-    when: node_port_services is defined
+    loop: "{{ data }}"
+    when: item.nodeport is not none
+
+  - name: Create pool list
+    ansible.builtin.set_fact:
+      pool_list: "{{ data | product(workerNodeNames) | list  }}"
+    when: data[0].nodeport is not none
 
   - name: Add members to each pool on loadbalancer
     openstack.cloud.lb_member:
       state: present
-      name: "{{ item[0] }}"
-      address: "{{ item[0] }}"
-      pool: "{{ item[1].NodePort }}"
-      protocol_port: "{{ item[1].NodePort }}"
-    with_nested:
-      - "{{ workerNodeNames }}"
-      - "{{ node_port_services }}"
-    when: node_port_services is defined
+      name: "{{ item.1 }}"
+      address: "{{ item.1 }}"
+      pool: "{{ item.0.nodeport }}"
+      protocol_port: "{{ item.0.nodeport }}"
+    loop: "{{ pool_list }}"
+    when: item is defined
 
   - name: Add health monitors to each members in each pool on loadbalancer
     openstack.cloud.lb_health_monitor:
       wait: true
       type: TCP
-      name: "{{ item.NodePort }}"
-      pool: "{{ item.NodePort }}"
+      name: "{{ item.nodeport }}"
+      pool: "{{ item.nodeport }}"
       max_retries: 3
       resp_timeout: 5
       delay: 10
-    with_items: "{{ node_port_services }}"
-    when: node_port_services is defined
+    loop: "{{ data }}"
+    when: item.nodeport is not none
+
+  - name: Grab nodeports from configmap
+    ansible.builtin.set_fact:
+      nodeports: "{{ data | map(attribute='nodeport') | map('string') | list }}"
+    when: data[0].nodeport is not none
 
   - name: Get NodePort loadbalancer listeners
     ansible.builtin.shell: openstack loadbalancer listener list -c name -f value
     register: nodePortLoadbalancerListener
+    when: data[0].nodeport is not none
 
   - name: Get NodePort loadbalancer pools
     ansible.builtin.shell: openstack loadbalancer pool list -c name -f value
     register: nodePortLoadbalancerPool
-
-  - name: Get NodePort loadbalancer members per pool
-    ansible.builtin.shell: openstack loadbalancer member list "{{ item }}" -c name -f value
-    with_items: "{{ nodePortLoadbalancerPool.stdout_lines }}"
-    register: nodePortLoadbalancerMember
-
-  - name: Set NodePort list
-    ansible.builtin.set_fact:
-      node_port_services_list: "{{ node_port_services_list | default([]) + [ item.NodePort ] }}"
-    with_items: "{{ node_port_services }}"
+    when: data[0].nodeport is not none
 
   - name: Determine what listeners to delete
     ansible.builtin.set_fact:
       loadbalancerListenersToDelete: "{{ loadbalancerListenersToDelete | default([]) + [ item ] }}"
-    with_items: "{{ nodePortLoadbalancerListener.stdout_lines }}"
+    loop: "{{ nodePortLoadbalancerListener.stdout_lines }}"
     when:
-      - node_port_services is defined
-      - item not in ports
+      - nodeports is defined
+      - item not in nodeports
 
   - name: Determine what pools to delete
     ansible.builtin.set_fact:
       loadbalancerPoolsToDelete: "{{ loadbalancerPoolsToDelete | default([]) + [ item ] }}"
     with_items: "{{ nodePortLoadbalancerPool.stdout_lines }}"
     when:
-      - node_port_services is defined
-      - item not in ports
+      - nodeports is defined
+      - item not in nodeports
 
   - name: Remove listensers from openstack
     openstack.cloud.lb_listener:
@@ -154,26 +162,28 @@
     with_items: "{{ loadbalancerPoolsToDelete }}"
     when: loadbalancerPoolsToDelete is defined
 
+  - name: Get NodePort loadbalancer pools after pool deletions
+    ansible.builtin.shell: openstack loadbalancer pool list -c name -f value
+    register: nodePortLoadbalancerPool
+    when: data[0].nodeport is not none
+
+  - name: Get NodePort loadbalancer members per pool
+    ansible.builtin.shell: openstack loadbalancer member list "{{ item }}" -c name -f value
+    with_items: "{{ nodePortLoadbalancerPool.stdout_lines }}"
+    register: nodePortLoadbalancerMember
+    when: data[0].nodeport is not none
+
   - name: Sanitise members list
     ansible.builtin.set_fact:
       loadbalancerMembersList: "{{ nodePortLoadbalancerMember | to_json | from_json | json_query(membersQuery) }}"
     vars:
       membersQuery: 'results[0].stdout_lines'
+    when: data[0].nodeport is not none
 
   - name: Determine what members to remove for each pool
     ansible.builtin.set_fact:
       loadbalancerMembersToRemove: "{{ loadbalancerMembersToRemove | default([]) + [ item ] }}"
     with_items: "{{ loadbalancerMembersList }}"
     when:
-      - nodePortLoadbalancerPool is defined
+      - nodePortLoadbalancerPool.stdout_lines is defined
       - item not in workerNodeNames
-    
-  - name: Remove member from each pool on loadbalancer
-    openstack.cloud.lb_member:
-      state: absent
-      name: "{{ item[0] }}"
-      pool: "{{ item[1] }}"
-    with_nested:
-      - "{{ loadbalancerMembersToRemove }}"
-      - "{{ node_port_services_list }}"
-    when: loadbalancerMembersToRemove is defined

--- a/post-deployment/openstack/nodeport-loadbalancing-ingress/main.yaml
+++ b/post-deployment/openstack/nodeport-loadbalancing-ingress/main.yaml
@@ -17,6 +17,16 @@
         metadata:
           name: "{{ namespace }}"
 
+  - name: Create ConfigMap
+    k8s:
+      state: present
+      definition:
+        api_version: v1
+        kind: ConfigMap
+        metadata:
+          name: "ukcloud-openstack-loadbalancer"
+          namespace: "{{ namespace }}"
+
   - name: Create secret containing sa token
     k8s:
       state: present

--- a/post-deployment/openstack/nodeport-loadbalancing-ingress/main.yaml
+++ b/post-deployment/openstack/nodeport-loadbalancing-ingress/main.yaml
@@ -1,0 +1,92 @@
+---
+- import_playbook: sa.yml
+
+- hosts: localhost
+  connection: local
+
+  vars:
+    namespace: "ukc-ingress"
+
+  tasks:
+  - name: Create "{{ namespace }}" namespace
+    k8s:
+      state: present
+      definition:
+        apiVersion: v1
+        kind: namespace
+        metadata:
+          name: "{{ namespace }}"
+
+  - name: Create secret containing sa token
+    k8s:
+      state: present
+      definition:
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: "ukc-ingress-sa"
+          namespace: "{{ namespace }}"
+        data:
+          token: "{{ ukcIngressSaToken | b64encode }}"
+
+  - name: Create ImageStream
+    k8s:
+      state: present
+      definition:
+        apiVersion: image.openshift.io/v1
+        kind: ImageStream
+        metadata:
+          name: update-nodeport-loadbalancer-members
+          namespace: "{{ namespace }}"
+        spec:
+          lookupPolicy:
+            local: true
+
+  - name: Create BuildConfig
+    k8s:
+      state: present
+      definition:
+        apiVersion: build.openshift.io/v1
+        kind: BuildConfig
+        metadata:
+          labels:
+            build: update-nodeport-loadbalancer-members
+          name: update-nodeport-loadbalancer-members
+          namespace: "{{ namespace }}"
+        spec:
+          output:
+            to:
+              kind: "ImageStreamTag"
+              name: update-nodeport-loadbalancer-members:latest
+          source:
+            binary: {}
+            type: Binary
+          strategy:
+            dockerStrategy: {}
+            type: Docker
+
+  - name: Run docker build
+    ansible.builtin.shell:
+      cmd: oc start-build update-nodeport-loadbalancer-members --from-dir . -F -n {{ namespace }}
+    args:
+      chdir: "./build"
+    register: updateNodePortbBuildStatus
+    until: 
+      - "'Push successful' in updateNodePortbBuildStatus.stdout_lines"
+    retries: 5
+    delay: 60
+
+  - name: Delete BuildConfig
+    k8s:
+      state: absent
+      definition:
+        apiVersion: build.openshift.io/v1
+        kind: BuildConfig
+        metadata:
+          name: update-nodeport-loadbalancer-members
+          namespace: "{{ namespace }}"
+
+  - name: Create update-nodeport-loadbalancer CronJob
+    k8s:
+      state: present
+      definition: "{{ lookup('template', 'templates/cronjob-update-nodeport-loadbalancer.j2') }}"

--- a/post-deployment/openstack/nodeport-loadbalancing-ingress/sa.yml
+++ b/post-deployment/openstack/nodeport-loadbalancing-ingress/sa.yml
@@ -1,0 +1,139 @@
+---
+- hosts: localhost
+  connection: local
+  gather_facts: false
+  
+  vars:
+    secrets:
+      - name: "openstack-credentials"
+        namespace: "kube-system"
+
+  tasks:
+  - name: 'Create ukc-ingress service account'
+    k8s:
+      state: present
+      definition:
+        apiVersion: v1
+        kind: ServiceAccount
+        metadata:
+          name: ukc-ingress
+          namespace: default
+
+  - name: 'Create ukc-ingress secret role'
+    k8s:
+      state: present
+      definition:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: Role
+        metadata:
+          name: ukc-ingress
+          namespace: "{{ item.namespace }}"
+        rules:
+        - apiGroups: [""]
+          resources: ["secrets"]
+          resourceNames: ["{{ item.name }}"]
+          verbs:
+          - get
+          - list
+          - watch
+    with_items: "{{ secrets }}"
+
+  - name: 'Create ukc-ingress rolebindings'
+    k8s:
+      state: present
+      definition:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        metadata:
+          name: "ukc-ingress"
+          namespace: "{{ item.namespace }}"
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: Role
+          name: ukc-ingress
+        subjects:
+        - kind: ServiceAccount
+          name: ukc-ingress
+          namespace: default
+    with_items: "{{ secrets }}"
+
+  - name: 'Create node-reader ClusterRole'
+    k8s:
+      state: present
+      definition:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        metadata:
+          name: node-reader
+        rules:
+          - apiGroups:
+            - ""
+            resources:
+            - nodes
+            verbs:
+            - get
+            - list
+            - watch
+
+  - name: Create services-reader ClusterRole
+    k8s:
+      state: present
+      definition:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        metadata:
+          name: services-reader
+        rules:
+          - apiGroups: [""]
+            resources: ["services"]
+            verbs: ["get", "watch", "list"]
+
+  - name: 'Create ukc-ingress-node-reader clusterrolebinding'
+    k8s:
+      state: present
+      definition:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        metadata:
+          name: "ukc-ingress-node-reader"
+        roleRef:
+          apiGroup: ""
+          kind: ClusterRole
+          name: node-reader
+        subjects:
+        - kind: ServiceAccount
+          name: ukc-ingress
+          namespace: default
+
+  - name: Create ukc-ingress-services-reader ClusterRoleBinding
+    k8s:
+      state: present
+      definition:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        metadata:
+          name: ukc-ingress-services-reader
+        subjects:
+        - kind: ServiceAccount
+          name: ukc-ingress
+          namespace: default
+        roleRef:
+          kind: ClusterRole
+          name: services-reader
+          apiGroup: ""
+
+  - name: 'Retrieve ukc-ingress token'
+    command: oc serviceaccounts get-token ukc-ingress -n default
+    register: ukcIngressToken
+
+  - name: 'Write token to variable'
+    set_fact:
+      ukcIngressSaToken: "{{ ukcIngressToken.stdout }}"
+
+  - name: 'Verify token'
+    uri:
+      url: "https://api.{{ domainSuffix }}:6443/api/v1"
+      return_content: yes
+      validate_certs: no
+      headers:
+        Authorization: "Bearer {{ ukcIngressSaToken }}"

--- a/post-deployment/openstack/nodeport-loadbalancing-ingress/sa.yml
+++ b/post-deployment/openstack/nodeport-loadbalancing-ingress/sa.yml
@@ -75,17 +75,18 @@
             - list
             - watch
 
-  - name: Create services-reader ClusterRole
+  - name: Create configmap-reader Role
     k8s:
       state: present
       definition:
         apiVersion: rbac.authorization.k8s.io/v1
-        kind: ClusterRole
+        kind: Role
         metadata:
-          name: services-reader
+          name: configmap-reader
+          namespace: ukc-ingress
         rules:
           - apiGroups: [""]
-            resources: ["services"]
+            resources: ["configmaps"]
             verbs: ["get", "watch", "list"]
 
   - name: 'Create ukc-ingress-node-reader clusterrolebinding'
@@ -105,21 +106,22 @@
           name: ukc-ingress
           namespace: default
 
-  - name: Create ukc-ingress-services-reader ClusterRoleBinding
+  - name: Create ukc-ingress-configmap-reader RoleBinding
     k8s:
       state: present
       definition:
         apiVersion: rbac.authorization.k8s.io/v1
-        kind: ClusterRoleBinding
+        kind: RoleBinding
         metadata:
-          name: ukc-ingress-services-reader
+          name: ukc-ingress-configmap-reader
+          namespace: ukc-ingress
         subjects:
         - kind: ServiceAccount
           name: ukc-ingress
           namespace: default
         roleRef:
-          kind: ClusterRole
-          name: services-reader
+          kind: Role
+          name: configmap-reader
           apiGroup: ""
 
   - name: 'Retrieve ukc-ingress token'

--- a/post-deployment/openstack/nodeport-loadbalancing-ingress/templates/cronjob-update-nodeport-loadbalancer.j2
+++ b/post-deployment/openstack/nodeport-loadbalancing-ingress/templates/cronjob-update-nodeport-loadbalancer.j2
@@ -1,0 +1,35 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: "update-nodeport-loadbalancer"
+  namespace: "{{ namespace }}"
+spec:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: "Replace"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        spec:
+          containers:
+          - name: update-nodeport-loadbalancer-members
+            image: update-nodeport-loadbalancer-members
+            env:
+            - name: K8S_AUTH_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "ukc-ingress-sa"
+                  key: token
+            - name: K8S_AUTH_HOST
+              value: "https://api.{{ domainSuffix}}:6443"
+            - name: OS_CLOUD
+              value: openstack
+            volumeMounts:
+            - mountPath: "/etc/openstack"
+              name: clouds
+          volumes:
+            - name: clouds
+              emptyDir: {}
+          restartPolicy: Never

--- a/post-deployment/openstack/post-deployment.yml
+++ b/post-deployment/openstack/post-deployment.yml
@@ -38,3 +38,4 @@
   when: extraGateway | default(false) | bool
 - import_playbook: ingress/letsencrypt.yml
   when: useLetsEncryptCert | default(true) | bool
+- import_playbook: nodeport-loadbalancing-ingress/main.yaml


### PR DESCRIPTION
- This enables a customer to expose NodePort services in their cluster.
- Utlizes a single OpenStack Octavia Loadbalancer with floating IP.
- Customer uses a configmap to define loadbalancer settings such as listener port, allowed ips and nodeport service
- Update the loadbalancers whenever cluster adds more nodes.