### PR TITLE
Limit retention for prometheus to 7 days

### DIFF
--- a/post-deployment/openstack/infra.yml
+++ b/post-deployment/openstack/infra.yml
@@ -64,6 +64,7 @@
             prometheusK8s:
               nodeSelector:
                 node-role.kubernetes.io/infra: ""
+              retention: 7d
             prometheusOperator:
               nodeSelector:
                 node-role.kubernetes.io/infra: ""
@@ -95,3 +96,25 @@
         spec:
           defaultNodeSelector: node-role.kubernetes.io/app=
           mastersSchedulable: false
+
+  - name: Create user-workload-monitoring configmap
+    k8s:
+      state: present
+      definition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: user-workload-monitoring-config
+          namespace: openshift-user-workload-monitoring
+        data:
+          config.yaml: |
+            prometheusOperator:
+              nodeSelector:
+                node-role.kubernetes.io/infra: ""
+            prometheus:
+              nodeSelector:
+                node-role.kubernetes.io/infra: ""
+              retention: 7d
+            thanosRuler:
+              nodeSelector:
+                node-role.kubernetes.io/infra: ""


### PR DESCRIPTION
**Also moves user-monitoring prometheus to infra nodes.** - I've never seen user monitoring prom take a lot of RAM or disk (like the main prometheus does...) so I think it is OK to have four prometheuses on 2 infra nodes... but we haven't had a customer make heavy use of it... so ... discuss?

In 4.8+, the `openshift-user-workload-monitoring` namespace is always present (even before `enableUserWorkload` is enabled), so my navel gazing about to how delay the creation of the config map until the namespace and user prometheus operator pod appears was unnecessary.