### PR TITLE
Non-net2 NTP

### DIFF
--- a/post-deployment/openstack/net2-ntp.yml
+++ b/post-deployment/openstack/net2-ntp.yml
@@ -23,7 +23,7 @@
         metadata:
           labels:
             machineconfiguration.openshift.io/role: net2
-          name: 03-net2-ntp
+          name: 09-net2-ntp
         spec:
           config:
             ignition:

--- a/post-deployment/openstack/ntp.yml
+++ b/post-deployment/openstack/ntp.yml
@@ -13,7 +13,7 @@
         rtcsync
         logdir /var/log/chrony  
 
-  - name: Create NTP MachineConfig
+  - name: Create master NTP MachineConfig
     k8s:
       state: present
       definition:
@@ -21,9 +21,8 @@
         kind: MachineConfig
         metadata:
           labels:
-            machineconfiguration.openshift.io/role: worker
             machineconfiguration.openshift.io/role: master
-          name: 03-ntp
+          name: 03-master-ntp
         spec:
           config:
             ignition:
@@ -36,3 +35,24 @@
                 contents:
                   source: "data:,{{ chronyconf | urlencode }}"  
 
+  - name: Create worker NTP MachineConfig
+    k8s:
+      state: present
+      definition:
+        apiVersion: machineconfiguration.openshift.io/v1
+        kind: MachineConfig
+        metadata:
+          labels:
+            machineconfiguration.openshift.io/role: worker
+          name: 03-worker-ntp
+        spec:
+          config:
+            ignition:
+              version: 3.2.0
+            storage:
+              files:
+              - path: /etc/chrony.conf
+                mode: 0644
+                overwrite: true
+                contents:
+                  source: "data:,{{ chronyconf | urlencode }}"  

--- a/post-deployment/openstack/ntp.yml
+++ b/post-deployment/openstack/ntp.yml
@@ -1,0 +1,38 @@
+---
+- hosts: localhost
+  connection: local
+
+  tasks:
+  - name: Template /etc/chrony.conf
+    set_fact: 
+      chronyconf: | 
+        {% for ntpserver in ntpServers %}server {{ ntpserver }} iburst
+        {% endfor %}
+        driftfile /var/lib/chrony/drift
+        makestep 1.0 3
+        rtcsync
+        logdir /var/log/chrony  
+
+  - name: Create NTP MachineConfig
+    k8s:
+      state: present
+      definition:
+        apiVersion: machineconfiguration.openshift.io/v1
+        kind: MachineConfig
+        metadata:
+          labels:
+            machineconfiguration.openshift.io/role: worker
+            machineconfiguration.openshift.io/role: master
+          name: 03-ntp
+        spec:
+          config:
+            ignition:
+              version: 3.2.0
+            storage:
+              files:
+              - path: /etc/chrony.conf
+                mode: 0644
+                overwrite: true
+                contents:
+                  source: "data:,{{ chronyconf | urlencode }}"  
+

--- a/post-deployment/openstack/post-deployment.yml
+++ b/post-deployment/openstack/post-deployment.yml
@@ -15,6 +15,8 @@
 - import_playbook: object-storage.yml
 - import_playbook: infra.yml
 - import_playbook: storage.yml
+- import_playbook: ntp.yml
+  when: ntpServers is defined
 - import_playbook: net2-ntp.yml
   when: net2 | default(false) | bool
 - import_playbook: logging.yml

--- a/post-deployment/openstack/vars.yml
+++ b/post-deployment/openstack/vars.yml
@@ -2,6 +2,9 @@ rhcosImage: <image present in project> # <Name of image to use for deploying inf
 domainSuffix: <domain suffix> # Can also be specified in two params "custID" and "baseDomain"
 workerFlavor: <flavor> # OpenStack flavor for the primary app worker MachineSet
 additionalFlavors: [] # List of other flavors to create worker MachineSets for
+
+#ntpServers: ["1.2.3.4","6.7.8.9"]    # NTP to configure on non-net2 nodes, rhel.pool.ntp.org used by default
+
 # SSO parameters
 ssoSecret: <secret>
 ssoClientID: <client ID>


### PR DESCRIPTION
Adds optional ntpServers `vars.yml` parameter which lets the NTP config of non-net2 (ie: Internet) nodes to be customised.

Parameter is an array of domain names or IPs, Eg:
```
ntpServers: ["0.uk.pool.ntp.org","1.uk.pool.ntp.org"]
```

Note that both `ntp.yml` and `net2-ntp.yml` create MachineConfigs that apply NTP config to the net2 workers. However since the `net2-ntp.yml` playbook makes a MachineConfig with a higher index number, that config takes precedence. 