### PR TITLE
Update logging.yml

### DIFF
--- a/post-deployment/openstack/logging.yml
+++ b/post-deployment/openstack/logging.yml
@@ -50,7 +50,7 @@
           name: "elasticsearch-operator"
           namespace: "openshift-operators-redhat"
         spec:
-          channel: "{{ 'stable' if openshiftVersion >= '4.7' else openshiftVersion }}"
+          channel: "stable"
           installPlanApproval: "Automatic"
           source: "redhat-operators"
           sourceNamespace: "openshift-marketplace"
@@ -132,7 +132,7 @@
           name: cluster-logging
           namespace: openshift-logging
         spec:
-          channel: "{{ 'stable' if openshiftVersion >= '4.7' else openshiftVersion }}"
+          channel: "stable"
           name: cluster-logging
           source: redhat-operators
           sourceNamespace: openshift-marketplace


### PR DESCRIPTION
This is to resolve a bug when setting the subscription channel to stable in deployments of v4.10.

Since we won't deply v4.7 ever again, this logic is no longer needed