### PR TITLE
Switch coredns pods to bridged networking

### DIFF
--- a/upi/vsphere/stage2/8.configure-svcs/Dockerfile
+++ b/upi/vsphere/stage2/8.configure-svcs/Dockerfile
@@ -1,5 +1,5 @@
 FROM docker.io/ansible/ansible-runner@sha256:bd09ef403f2f90f2c6bd133d7533e939058903f69223c5f12557a49e3aed14bb
 ADD ./playbooks /usr/local/playbooks
-RUN yum install -y bind-utils; yum clean all
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*; sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*; yum install -y bind-utils; yum clean all
 WORKDIR /tmp/workingdir
 ENTRYPOINT /usr/local/playbooks/entrypoint.sh

--- a/upi/vsphere/stage2/8.configure-svcs/playbooks/templates/coredns.service.j2
+++ b/upi/vsphere/stage2/8.configure-svcs/playbooks/templates/coredns.service.j2
@@ -5,7 +5,7 @@ Wants=crio.service
 Restart=always
 RestartSec=5
 ExecStartPre=/bin/sleep 3
-ExecStart=/usr/bin/podman run --rm=true -a=STDOUT --name coredns --read-only -v /etc/coredns:/etc/coredns:ro,noexec --network host -p 53:53/udp {{ registry_url }}/coredns:{{ image_tag }} --conf /etc/coredns/Corefile
+ExecStart=/usr/bin/podman run --rm=true -a=STDOUT --name coredns --read-only -v /etc/coredns:/etc/coredns:ro,noexec -p 53:53/udp {{ registry_url }}/coredns:{{ image_tag }} --conf /etc/coredns/Corefile
 ExecStop=/usr/bin/podman kill --signal SIGQUIT coredns
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Host based networking was used for unknown reasons... preprod tests have revealed that bridged container networking works fine.

A change to the Dockerfile is needed to ensure that the deploy/scaleup container can build in this world where CentOS is depreciated... :( 