### PR TITLE
Change ansible-runner image repository

### DIFF
--- a/post-deployment/openstack/eg-ingress/build/Dockerfile
+++ b/post-deployment/openstack/eg-ingress/build/Dockerfile
@@ -1,5 +1,5 @@
 # FROM ansible-runner:latest
-FROM docker.io/ansible/ansible-runner@sha256:4c6034798b5e724c5a59466f5438e14480c53bc4adac5cc9db5e3997a286a0e4
+FROM quay.io/ansible/ansible-runner:stable-2.9-latest
 
 WORKDIR /usr/local/
 

--- a/post-deployment/openstack/ingress/build/Dockerfile
+++ b/post-deployment/openstack/ingress/build/Dockerfile
@@ -1,5 +1,5 @@
 # FROM ansible-runner:latest
-FROM docker.io/ansible/ansible-runner@sha256:4c6034798b5e724c5a59466f5438e14480c53bc4adac5cc9db5e3997a286a0e4
+FROM quay.io/ansible/ansible-runner:stable-2.9-latest
 
 WORKDIR /usr/local/
 

--- a/post-deployment/openstack/net2-ingress/build/Dockerfile
+++ b/post-deployment/openstack/net2-ingress/build/Dockerfile
@@ -1,5 +1,5 @@
 # FROM ansible-runner:latest
-FROM docker.io/ansible/ansible-runner@sha256:4c6034798b5e724c5a59466f5438e14480c53bc4adac5cc9db5e3997a286a0e4
+FROM quay.io/ansible/ansible-runner:stable-2.9-latest
 
 WORKDIR /usr/local/
 


### PR DESCRIPTION
The ansible-runner image existed in docker hub until recently. It has now moved to quay and this should enable eg, ingress and net2 post-deployments to work again