### PR TITLE
Tolerations to implement infras

### DIFF
--- a/post-deployment/openstack/eg-ingress/main.yml
+++ b/post-deployment/openstack/eg-ingress/main.yml
@@ -85,6 +85,10 @@
             nodeSelector:
               matchLabels:
                 node-role.kubernetes.io/infra: ""
+            tolerations:
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/infra
+                operator: Exists                
           endpointPublishingStrategy:
             type: NodePortService
           replicas: 0

--- a/post-deployment/openstack/infra.yml
+++ b/post-deployment/openstack/infra.yml
@@ -31,6 +31,10 @@
               destination:
                 type: Container
           nodePlacement:
+            tolerations:
+              - effect: NoSchedule 
+                key: node-role.kubernetes.io/infra 
+                operator: Exists
             nodeSelector:
               matchLabels:
                 node-role.kubernetes.io/infra: ""
@@ -46,6 +50,10 @@
         spec:
           nodeSelector:
             node-role.kubernetes.io/infra: ""
+          tolerations:
+            - effect: NoSchedule 
+              key: node-role.kubernetes.io/infra 
+              operator: Exists
 
   - name: Create cluster-monitoring configmap
     k8s:
@@ -61,41 +69,61 @@
             alertmanagerMain:
               nodeSelector:
                 node-role.kubernetes.io/infra: ""
+              tolerations:
+                - effect: NoSchedule 
+                  key: node-role.kubernetes.io/infra 
+                  operator: Exists
             prometheusK8s:
               nodeSelector:
                 node-role.kubernetes.io/infra: ""
+              tolerations:
+                - effect: NoSchedule 
+                  key: node-role.kubernetes.io/infra 
+                  operator: Exists
               retention: 7d
             prometheusOperator:
               nodeSelector:
                 node-role.kubernetes.io/infra: ""
+              tolerations:
+                - effect: NoSchedule 
+                  key: node-role.kubernetes.io/infra 
+                  operator: Exists
             grafana:
               nodeSelector:
                 node-role.kubernetes.io/infra: ""
+              tolerations:
+                - effect: NoSchedule 
+                  key: node-role.kubernetes.io/infra 
+                  operator: Exists
             k8sPrometheusAdapter:
               nodeSelector:
                 node-role.kubernetes.io/infra: ""
+              tolerations:
+                - effect: NoSchedule 
+                  key: node-role.kubernetes.io/infra 
+                  operator: Exists
             kubeStateMetrics:
               nodeSelector:
                 node-role.kubernetes.io/infra: ""
+              tolerations:
+                - effect: NoSchedule 
+                  key: node-role.kubernetes.io/infra 
+                  operator: Exists
             telemeterClient:
               nodeSelector:
                 node-role.kubernetes.io/infra: ""
+              tolerations:
+                - effect: NoSchedule 
+                  key: node-role.kubernetes.io/infra 
+                  operator: Exists
             openshiftStateMetrics:
               nodeSelector:
                 node-role.kubernetes.io/infra: ""
+              tolerations:
+                - effect: NoSchedule 
+                  key: node-role.kubernetes.io/infra 
+                  operator: Exists
             enableUserWorkload: true
-
-  - name: Create default nodeSelector to target workers
-    k8s:
-      state: present
-      definition:
-        apiVersion: config.openshift.io/v1
-        kind: Scheduler
-        metadata:
-          name: cluster
-        spec:
-          defaultNodeSelector: node-role.kubernetes.io/app=
-          mastersSchedulable: false
 
   - name: Create user-workload-monitoring configmap
     k8s:
@@ -111,10 +139,22 @@
             prometheusOperator:
               nodeSelector:
                 node-role.kubernetes.io/infra: ""
+              tolerations:
+                - effect: NoSchedule 
+                  key: node-role.kubernetes.io/infra 
+                  operator: Exists
             prometheus:
               nodeSelector:
                 node-role.kubernetes.io/infra: ""
+              tolerations:
+                - effect: NoSchedule 
+                  key: node-role.kubernetes.io/infra 
+                  operator: Exists
               retention: 7d
             thanosRuler:
               nodeSelector:
                 node-role.kubernetes.io/infra: ""
+              tolerations:
+                - effect: NoSchedule 
+                  key: node-role.kubernetes.io/infra 
+                  operator: Exists

--- a/post-deployment/openstack/logging.yml
+++ b/post-deployment/openstack/logging.yml
@@ -166,7 +166,11 @@
           collection:
             logs:
               type: "fluentd"
-              fluentd: {}
+              fluentd:
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
           curation:
             type: "curator"
             curator:

--- a/post-deployment/openstack/logging.yml
+++ b/post-deployment/openstack/logging.yml
@@ -176,7 +176,7 @@
                 - effect: NoSchedule
                   key: node-role.kubernetes.io/infra
                   operator: Exists
-              schedula: 0 1 * * *
+              schedule: 0 1 * * *
           logStore:
             type: "elasticsearch"
             retentionPolicy:

--- a/post-deployment/openstack/logging.yml
+++ b/post-deployment/openstack/logging.yml
@@ -172,10 +172,14 @@
             curator:
               nodeSelector:
                 node-role.kubernetes.io/infra: ""
-              schedule: 0 1 * * *
+              tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+              schedula: 0 1 * * *
           logStore:
             type: "elasticsearch"
-            retentionPolicy: 
+            retentionPolicy:
               application:
                 maxAge: 7d
               infra:
@@ -186,6 +190,10 @@
               nodeCount: 1
               nodeSelector:
                 node-role.kubernetes.io/infra: ""
+              tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
               redundancyPolicy: "ZeroRedundancy"
               storage:
                 size: "200G"
@@ -202,4 +210,8 @@
             kibana:
               nodeSelector:
                 node-role.kubernetes.io/infra: ""
+              tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
               replicas: 1

--- a/post-deployment/openstack/logging.yml
+++ b/post-deployment/openstack/logging.yml
@@ -177,9 +177,9 @@
               nodeSelector:
                 node-role.kubernetes.io/infra: ""
               tolerations:
-                - effect: NoSchedule
-                  key: node-role.kubernetes.io/infra
-                  operator: Exists
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/infra
+                operator: Exists
               schedule: 0 1 * * *
           logStore:
             type: "elasticsearch"
@@ -195,9 +195,9 @@
               nodeSelector:
                 node-role.kubernetes.io/infra: ""
               tolerations:
-                - effect: NoSchedule
-                  key: node-role.kubernetes.io/infra
-                  operator: Exists
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/infra
+                operator: Exists
               redundancyPolicy: "ZeroRedundancy"
               storage:
                 size: "200G"
@@ -215,7 +215,7 @@
               nodeSelector:
                 node-role.kubernetes.io/infra: ""
               tolerations:
-                - effect: NoSchedule
-                  key: node-role.kubernetes.io/infra
-                  operator: Exists
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/infra
+                operator: Exists
               replicas: 1

--- a/post-deployment/openstack/logging.yml
+++ b/post-deployment/openstack/logging.yml
@@ -168,18 +168,18 @@
               type: "fluentd"
               fluentd:
                 tolerations:
-                - effect: NoSchedule
-                  key: node-role.kubernetes.io/infra
-                  operator: Exists
+                  - effect: NoSchedule
+                    key: node-role.kubernetes.io/infra
+                    operator: Exists
           curation:
             type: "curator"
             curator:
               nodeSelector:
                 node-role.kubernetes.io/infra: ""
               tolerations:
-              - effect: NoSchedule
-                key: node-role.kubernetes.io/infra
-                operator: Exists
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
               schedule: 0 1 * * *
           logStore:
             type: "elasticsearch"
@@ -195,9 +195,9 @@
               nodeSelector:
                 node-role.kubernetes.io/infra: ""
               tolerations:
-              - effect: NoSchedule
-                key: node-role.kubernetes.io/infra
-                operator: Exists
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
               redundancyPolicy: "ZeroRedundancy"
               storage:
                 size: "200G"
@@ -215,7 +215,7 @@
               nodeSelector:
                 node-role.kubernetes.io/infra: ""
               tolerations:
-              - effect: NoSchedule
-                key: node-role.kubernetes.io/infra
-                operator: Exists
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
               replicas: 1


### PR DESCRIPTION
This adds tolerations to match the taints added to infras in https://github.com/UKCloud/openshift-upi-ansible/pull/32

This makes our clusters more compliant with Red Hat recommendations to strongly prevent customer workloads from running on infras using taints. Also, this removes the default nodeselector.